### PR TITLE
Fix istio/lint bad substitution error

### DIFF
--- a/files/scripts/check_dockerfiles.sh
+++ b/files/scripts/check_dockerfiles.sh
@@ -23,13 +23,14 @@
 
 set -e
 
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPTPATH="$( cd "$( dirname "${0}")" && pwd -P)"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
 cd "${ROOTDIR}"
 
 CD_TMPFILE=$(mktemp /tmp/check_dockerfile.XXXXXX)
 HL_TMPFILE=$(mktemp /tmp/hadolint.XXXXXX)
 
+# shellcheck disable=SC2044
 for df in $(find "${ROOTDIR}" -path "${ROOTDIR}/vendor" -prune -o -name 'Dockerfile*'); do
   docker run --rm -i hadolint/hadolint:v1.17.1 < "$df" > "${HL_TMPFILE}"
   if [ "" != "$(cat "${HL_TMPFILE}")" ]

--- a/files/scripts/check_dockerfiles.sh
+++ b/files/scripts/check_dockerfiles.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
 #
@@ -23,7 +23,7 @@
 
 set -e
 
-SCRIPTPATH="$( cd "$( dirname "${0}")" && pwd -P)"
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
 cd "${ROOTDIR}"
 


### PR DESCRIPTION
Despite working on my setup, and passing shellcheck, the SCRIPTPATH substitution did not work as intended in prow.
This fix has been tested on the prow pipeline, but I need to get it back to common-files source.