### PR TITLE
Fix the generated .commonfiles.sha

### DIFF
--- a/files/Makefile.common.mk
+++ b/files/Makefile.common.mk
@@ -21,7 +21,6 @@
 
 updatecommon:
 	@git clone --depth 1 --single-branch --branch master https://github.com/istio/common-files
-	@cd common-files
-	@git rev-parse HEAD >.commonfiles.sha
-	@cp -r common-files/files/* common-files/files/.[^.]* .
+	@cd common-files ; git rev-parse HEAD >.commonfiles.sha
+	@cp -r common-files/files/* common-files/.commonfiles.sha common-files/files/.[^.]* .
 	@rm -fr common-files


### PR DESCRIPTION
The generated .commonfiles.sha for a `make updatecommon` ends up containing the commit id of the repo where the update was happening. I assume it should contain the commit id of the common-files repo that was actually used.