### PR TITLE
Update Makefile to latest container image

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -30,7 +30,7 @@ RUN =
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 ifeq ($(BUILD_WITH_CONTAINER),1)
-IMG = gcr.io/istio-testing/build-tools:2019-08-15
+IMG = gcr.io/istio-testing/build-tools:2019-08-16
 UID = $(shell id -u)
 PWD = $(shell pwd)
 GOBIN_SOURCE ?= $(GOPATH)/bin


### PR DESCRIPTION
We need to use the latest container image in the operator
repository to enable container based builds (finally).

Depends-On: https://github.com/istio/tools/pull/274