### PR TITLE
Linting tweaks.

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -39,10 +39,22 @@ lint-copyright-banner:
 	 	${XARGS} common/scripts/lint_copyright_banner.sh
 
 lint-go:
-	@golangci-lint run -j 8 -c ./common/config/.golangci.yml
+	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | : | ${XARGS} golangci-lint run -j 8 -c ./common/config/.golangci.yml
 
 lint-python:
 	@${FINDFILES} -name '*.py' -print0 | ${XARGS} autopep8 --max-line-length 160 --exit-code -d
+
+lint-markdown:
+	@${FINDFILES} -name '*.md' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb
+	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow_ssl --allow-timeout --allow-dupe --allow-redirect
+
+lint-sass:
+	@${FINDFILES} -name '*.scss' -print0 | ${XARGS} sass-lint -c common/config/sass-lint.yml --verbose
+
+lint-typescript:
+	@${FINDFILES} -name '*.ts' -print0 | ${XARGS} tslint -c common/config/tslint.json
+
+lint-all: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-markdown lint-sass lint-typescript
 
 format-go:
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} goimports -w -local "istio.io"
@@ -63,4 +75,4 @@ update-common-protos:
 	@cp -ar common-files/common-protos common-protos
 	@rm -fr common-files
 
-.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-pyhton lint-helm format-go format-python update-common update-common-protos
+.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-pyhton lint-helm lint-markdown lint-sass lint-typescript lint-all format-go format-python update-common update-common-protos

--- a/files/common/config/mdl.rb
+++ b/files/common/config/mdl.rb
@@ -1,0 +1,12 @@
+all
+rule 'MD002', :level => 2
+rule 'MD007', :indent => 4
+rule 'MD013', :line_length => 160, :code_blocks => false, :tables => false
+rule 'MD026', :punctuation => ".,;:!"
+exclude_rule 'MD013'
+exclude_rule 'MD014'
+exclude_rule 'MD030'
+exclude_rule 'MD032'
+exclude_rule 'MD033'
+exclude_rule 'MD041'
+exclude_rule 'MD046'

--- a/files/common/config/sass-lint.yml
+++ b/files/common/config/sass-lint.yml
@@ -1,0 +1,98 @@
+#########################
+## Config for sass-lint
+#########################
+# Linter Options
+options:
+  # Don't merge default rules
+  merge-default-rules: false
+  # Raise an error if more than 50 warnings are generated
+  max-warnings: 500
+# Rule Configuration
+rules:
+  attribute-quotes:
+    - 2
+    -
+      include: false
+  bem-depth: 2
+  border-zero: 2
+  brace-style: 2
+  class-name-format: 2
+  clean-import-paths: 2
+  declarations-before-nesting: 2
+  empty-args: 2
+  empty-line-between-blocks: 2
+  extends-before-declarations: 2
+  extends-before-mixins: 2
+  final-newline: 2
+  force-attribute-nesting: 0
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+  function-name-format: 2
+  hex-length: 0
+  hex-notation: 2
+  id-name-format: 2
+  indentation:
+    - 2
+    -
+      size: 4
+  leading-zero:
+    - 2
+    -
+      include: false
+  max-file-line-count: 0
+  max-file-length: 0
+  mixins-before-declarations: 2
+  no-attribute-selectors: 0
+  no-color-hex: 0
+  no-color-keywords: 0
+  no-color-literals: 0
+  no-combinators: 0
+  no-css-comments: 2
+  no-debug: 2
+  no-disallowed-properties: 2
+  no-duplicate-properties: 2
+  no-empty-rulesets: 2
+  no-extends: 2
+  no-ids: 0
+  no-invalid-hex: 2
+  no-important: 0
+  no-mergeable-selectors: 2
+  no-misspelled-properties: 2
+  no-qualifying-elements: 0
+  no-trailing-whitespace: 2
+  no-trailing-zero: 2
+  no-transition-all: 0
+  no-url-domains: 2
+  no-url-protocols: 2
+  no-warn: 2
+  one-declaration-per-line: 2
+  placeholder-in-extend: 2
+  placeholder-name-format: 2
+  property-sort-order: 0
+  property-units: 2
+  pseudo-element: 2
+  quotes:
+    - 2
+    -
+      style: double
+  shorthand-values: 2
+  single-line-per-selector: 0
+  space-after-bang: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang: 2
+  space-before-brace: 2
+  space-before-colon: 2
+  space-between-parens: 2
+  trailing-semicolon: 2
+  url-quotes: 2
+  variable-for-property:
+    - 0
+    -
+      properties:
+        - color
+        - background-color
+        - fill
+  variable-name-format: 0
+  zero-unit: 2

--- a/files/common/config/tslint.json
+++ b/files/common/config/tslint.json
@@ -1,0 +1,25 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "rules": {
+        "max-line-length": {
+            "options": [160]
+        },
+        "arrow-parens": false,
+        "new-parens": true,
+        "no-arg": true,
+        "no-bitwise": true,
+        "no-conditional-assignment": true,
+        "no-consecutive-blank-lines": true,
+        "no-console": {
+            "severity": "warning",
+            "options": ["debug", "info", "log", "time", "timeEnd", "trace"]
+        },
+        "no-shadowed-variable": false,
+        "eofline": false
+    },
+    "jsRules": {},
+    "rulesDirectory": []
+}


### PR DESCRIPTION
- Added a lint-all target which most repos should depend on.

- Make it so lint-go only launches golangci-lint if there are in fact .go files to lint. Otherwise, the tool complains it has no go files, which makes it so you couldn't use lint-go on non-go repos like istio.io, which means you can't use lint-all. Now you can :-)