### PR TITLE
Cleanup.

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -63,14 +63,14 @@ format-python:
 	@${FINDFILES} -name '*.py' -print0 | ${XARGS} autopep8 --max-line-length 160 --aggressive --aggressive -i
 
 update-common:
-	@git clone --depth 1 --single-branch --branch master https://github.com/istio/common-files
+	@git clone -q --depth 1 --single-branch --branch master https://github.com/istio/common-files
 	@cd common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
 	@cp -r common-files/files/* .
 	@rm -fr common-files
 
 update-common-protos:
-	@git clone --depth 1 --single-branch --branch master https://github.com/istio/common-files
+	@git clone -q --depth 1 --single-branch --branch master https://github.com/istio/common-files
 	@cd common-files ; git rev-parse HEAD > common-protos/.commonfiles.sha
 	@cp -ar common-files/common-protos common-protos
 	@rm -fr common-files

--- a/files/common/config/mdl.rb
+++ b/files/common/config/mdl.rb
@@ -1,5 +1,5 @@
 all
-rule 'MD002', :level => 2
+rule 'MD002', :level => 1
 rule 'MD007', :indent => 4
 rule 'MD013', :line_length => 160, :code_blocks => false, :tables => false
 rule 'MD026', :punctuation => ".,;:!"


### PR DESCRIPTION
- Fix markdown linting for non-istio.io files to start headers at H1 instead of H2.

- Pass -q to git clone to shut up the useless download data info.