### PR TITLE
Exclude common-protos from linting.

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FINDFILES=find . \( -path ./vendor -o -path ./.git \) -prune -o -type f
+FINDFILES=find . \( -path ./common-protos -o -path ./.git \) -prune -o -type f
 XARGS = xargs -0 -r
 
 lint-dockerfiles:


### PR DESCRIPTION
And no need to exclude 'vendor' since we don't have that anymore.
