### PR TITLE
Add support to lint the common files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lint:
+	@cp files/common/Makefile.common.mk files/Makefile.core.mk
+	@echo >files/Makefile.overrides.mk "BUILD_WITH_CONTAINER ?= 1"
+	@cd files && make -f Makefile lint-all
+	@rm files/Makefile.core.mk files/Makefile.overrides.mk

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -42,7 +42,7 @@ lint-go:
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | : | ${XARGS} golangci-lint run -j 8 -c ./common/config/.golangci.yml
 
 lint-python:
-	@${FINDFILES} -name '*.py' -print0 | ${XARGS} autopep8 --max-line-length 160 --exit-code -d
+	@${FINDFILES} -name '*.py' \( ! \( -name '*_pb2.py' \) \) -print0 | ${XARGS} autopep8 --max-line-length 160 --exit-code -d
 
 lint-markdown:
 	@${FINDFILES} -name '*.md' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb


### PR DESCRIPTION
- Also, stop linting generated Python files.
