### PR TITLE
Use realpath instead of readlink

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -65,7 +65,7 @@ RUN = docker run -t -i --sig-proxy=true -u $(UID) --rm \
 	-e GOBIN="$(GOBIN)" \
 	-e BUILD_WITH_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-v /etc/passwd:/etc/passwd:ro \
-	-v $(readlink /etc/localtime):/etc/localtime:ro \
+	-v $(realpath /etc/localtime):/etc/localtime:ro \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	$(CONTAINER_OPTIONS) \
 	--mount type=bind,source="$(PWD)",destination="/work" \


### PR DESCRIPTION
Output of readlink on linux is something like
```
$ readlink /etc/localtime
../usr/share/zoneinfo/America/New_York
```

Which breaks the `-v` docker cli option

realpath works fine:
```
$ realpath /etc/localtime
/usr/share/zoneinfo/America/New_York
```