### PR TITLE
Common file fixes.

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -29,7 +29,7 @@
 export BUILD_WITH_CONTAINER ?= 0
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
-IMG = gcr.io/istio-testing/build-tools:2019-09-04T21-28-42
+IMG = gcr.io/istio-testing/build-tools:2019-09-11T09-52-48
 UID = $(shell id -u)
 PWD = $(shell pwd)
 GOBIN_SOURCE ?= $(GOPATH)/bin
@@ -74,7 +74,6 @@ RUN = docker run -t -i --sig-proxy=true -u $(UID) --rm \
 	--mount type=bind,source="$(GOBIN_SOURCE)",destination="/go/out/bin" \
 	-w /work $(IMG)
 else
-export GOBIN ?= $(pwd)/out/bin
 RUN =
 endif
 

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -55,7 +55,7 @@ lint-typescript:
 	@${FINDFILES} -name '*.ts' -print0 | ${XARGS} tslint -c common/config/tslint.json
 
 lint-protos:
-	@$(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool lint --protoc-bin-path=/usr/bin/protoc --protoc-wkt-path=common-protos
+	@if test -d common-protos; then $(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool lint --protoc-bin-path=/usr/bin/protoc --protoc-wkt-path=common-protos; fi
 
 lint-all: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-markdown lint-sass lint-typescript lint-protos
 


### PR DESCRIPTION
- Turns out GOBIN needs to be undefined for non-container builds.

- Fix proto linting for the tools repo.

- Update to latest build-tools image.