### PR TITLE
Set default make goal

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.DEFAULT_GOAL := default
+
 # allow optional per-repo overrides
 -include Makefile.overrides.mk
 


### PR DESCRIPTION
I tried to build the code accroding to https://github.com/istio/istio/wiki/Using-the-Code-Base#building-the-code, but there was an error:
```
make[1]: Nothing to be done for 'bin'.
```
I think this is because there is no default make goal.
This PR will fix this issue.
