### PR TITLE
Update container image.

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -31,7 +31,7 @@ export BUILD_WITH_CONTAINER ?= 0
 ifeq ($(BUILD_WITH_CONTAINER),1)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
+IMG ?= gcr.io/istio-testing/build-tools:2019-09-20T15-04-58
 UID = $(shell id -u)
 PWD = $(shell pwd)
 GOBIN_SOURCE ?= $(GOPATH)/bin
@@ -53,10 +53,10 @@ GOARCH ?= $(GOARCH_LOCAL)
 LOCAL_OS := $(shell uname)
 ifeq ($(LOCAL_OS),Linux)
    GOOS_LOCAL = linux
-   read_link = readlink -f
+   read_link=$(readlink -f /etc/localtime)
 else ifeq ($(LOCAL_OS),Darwin)
    GOOS_LOCAL = darwin
-   read_link = readlink
+   read_link=$(readlink /etc/localtime)
 else
    $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
 endif
@@ -69,7 +69,7 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID) --rm \
 	-e GOBIN="$(GOBIN)" \
 	-e BUILD_WITH_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-v /etc/passwd:/etc/passwd:ro \
-	-v $(shell $(read_link) /etc/localtime):/etc/localtime:ro \
+	-v $(read_link):/etc/localtime:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
 	--mount type=bind,source="$(PWD)",destination="/work" \

--- a/files/common/scripts/gobuild.sh
+++ b/files/common/scripts/gobuild.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
 #
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
 # Copyright Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,9 +40,10 @@ set -e
 BUILD_GOOS=${GOOS:-linux}
 BUILD_GOARCH=${GOARCH:-amd64}
 GOBINARY=${GOBINARY:-go}
+GOPKG="$GOPATH/pkg"
 BUILDINFO=${BUILDINFO:-""}
 STATIC=${STATIC:-1}
-LDFLAGS="-extldflags -static"
+LDFLAGS=${LDFLAGS:--extldflags -static}
 GOBUILDFLAGS=${GOBUILDFLAGS:-""}
 # Split GOBUILDFLAGS by spaces into an array called GOBUILDFLAGS_ARRAY.
 IFS=' ' read -r -a GOBUILDFLAGS_ARRAY <<< "$GOBUILDFLAGS"
@@ -57,6 +65,7 @@ fi
 
 # BUILD LD_EXTRAFLAGS
 LD_EXTRAFLAGS=""
+
 while read -r line; do
     LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
@@ -65,4 +74,5 @@ time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \
         -o "${OUT}" \
         -trimpath \
+        -pkgdir="${GOPKG}/${BUILD_GOOS}_${BUILD_GOARCH}" \
         -ldflags "${LDFLAGS} ${LD_EXTRAFLAGS}" "${@}"

--- a/files/common/scripts/report_build_info.sh
+++ b/files/common/scripts/report_build_info.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
 # Copyright Istio Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Switch to latest build-tools container.

- Integrate changes from istio/istio/bin/gobuild.sh into the common gobuild.sh so that I can
delete the dedicated istio/istio version.

- Fix problems with readlink usage.
