### PR TITLE
Adapt to latest build tools container.

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -31,33 +31,15 @@ export BUILD_WITH_CONTAINER ?= 0
 ifeq ($(BUILD_WITH_CONTAINER),1)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-09-23T14-42-58
+IMG ?= gcr.io/istio-testing/build-tools:2019-09-23T12-48-14
 UID = $(shell id -u)
 PWD = $(shell pwd)
 
-LOCAL_ARCH := $(shell uname -m)
-ifeq ($(LOCAL_ARCH),x86_64)
-GOARCH_LOCAL := amd64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
-GOARCH_LOCAL := arm64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
-GOARCH_LOCAL := arm
-else
-GOARCH_LOCAL := $(LOCAL_ARCH)
-endif
-
-GOARCH ?= $(GOARCH_LOCAL)
-
 LOCAL_OS := $(shell uname)
 ifeq ($(LOCAL_OS),Linux)
-   GOOS_LOCAL = linux
-   # Apparently Linux needs a -f flag.
    READLINK_FLAGS="-f"
 else ifeq ($(LOCAL_OS),Darwin)
-   GOOS_LOCAL = darwin
    READLINK_FLAGS=""
-else
-   $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
 endif
 
 # Determine the timezone across various platforms to pass into the
@@ -65,19 +47,14 @@ endif
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
-GOOS ?= $(GOOS_LOCAL)
-
 RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID) --rm \
-	-e GOOS="$(GOOS)" \
-	-e GOARCH="$(GOARCH)" \
 	-e BUILD_WITH_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
 	--mount type=bind,source="$(PWD)",destination="/work" \
-	--mount type=volume,source=istio-go-mod,destination="/go/pkg/mod" \
-	--mount type=volume,source=istio-go-cache,destination="/gocache" \
+	--mount type=volume,source=home,destination="/home" \
 	-w /work $(IMG)
 else
 RUN =

--- a/files/Makefile
+++ b/files/Makefile
@@ -28,19 +28,38 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
+LOCAL_ARCH := $(shell uname -m)
+ifeq ($(LOCAL_ARCH),x86_64)
+    TARGET_ARCH ?= amd64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
+    TARGET_ARCH ?= arm64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
+    TARGET_ARCH ?= arm
+else
+   $(error "This system's architecture $(LOCAL_ARCH) isn't recognized/supported")
+endif
+
+LOCAL_OS := $(shell uname)
+ifeq ($(LOCAL_OS),Linux)
+   TARGET_OS ?= linux
+   READLINK_FLAGS="-f"
+else ifeq ($(LOCAL_OS),Darwin)
+   TARGET_OS ?= darwin
+   READLINK_FLAGS=""
+else
+   $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
+endif
+
+REPO_ROOT = $(shell git rev-parse --show-toplevel)
+REPO_NAME = $(shell basename $(REPO_ROOT))
+TARGET_OUT ?= $(HOME)/istio_out/$(REPO_NAME)
+
 ifeq ($(BUILD_WITH_CONTAINER),1)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:2019-09-23T12-48-14
 UID = $(shell id -u)
 PWD = $(shell pwd)
-
-LOCAL_OS := $(shell uname)
-ifeq ($(LOCAL_OS),Linux)
-   READLINK_FLAGS="-f"
-else ifeq ($(LOCAL_OS),Darwin)
-   READLINK_FLAGS=""
-endif
 
 # Determine the timezone across various platforms to pass into the
 # docker run operation. This operation assumes zoneinfo is within
@@ -50,10 +69,13 @@ TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'
 RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID) --rm \
 	-e BUILD_WITH_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
+	-e TARGET_ARCH="$(TARGET_ARCH)" \
+	-e TARGET_OS="$(TARGET_OS)" \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
 	--mount type=bind,source="$(PWD)",destination="/work" \
+	--mount type=bind,source="$(TARGET_OUT)",destination="/targetout" \
 	--mount type=volume,source=home,destination="/home" \
 	-w /work $(IMG)
 else
@@ -63,9 +85,11 @@ endif
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 
 %:
+	@mkdir -p $(TARGET_OUT)
 	@$(MAKE) $@
 
 default:
+	@mkdir -p $(TARGET_OUT)
 	@$(MAKE)
 
 .PHONY: default


### PR DESCRIPTION
- No longer pass GOARCH/GOOS to docker, we don't need that when
building from the container.