### PR TITLE
Set the docker group ID in the make operation

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -68,7 +68,7 @@ $(info Building with the build container: $(IMG).)
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
-RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID) --rm \
+RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	-e TZ="$(TIMEZONE)" \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \


### PR DESCRIPTION
This permits the access of /var/lib/docker which is permission 660 on
the host.  the socket is owned by group docker.