### PR TITLE
extract BUILD_WITH_CONTAINER docker command into a script

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -28,60 +28,11 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
-LOCAL_ARCH := $(shell uname -m)
-ifeq ($(LOCAL_ARCH),x86_64)
-    TARGET_ARCH ?= amd64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
-    TARGET_ARCH ?= arm64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
-    TARGET_ARCH ?= arm
-else
-    $(error This system's architecture $(LOCAL_ARCH) isn't supported)
-endif
-
-LOCAL_OS := $(shell uname)
-ifeq ($(LOCAL_OS),Linux)
-    TARGET_OS ?= linux
-    READLINK_FLAGS="-f"
-else ifeq ($(LOCAL_OS),Darwin)
-    TARGET_OS ?= darwin
-    READLINK_FLAGS=""
-else
-    $(error This system's OS $(LOCAL_OS) isn't supported)
-endif
-
-export TARGET_OUT ?= $(shell pwd)/out/$(TARGET_ARCH)_$(TARGET_OS)
-
 ifeq ($(BUILD_WITH_CONTAINER),1)
-export TARGET_OUT = /work/out/$(TARGET_ARCH)_$(TARGET_OS)
-CONTAINER_CLI ?= docker
-DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
-UID = $(shell id -u)
-PWD = $(shell pwd)
-
-$(info Building with the build container: $(IMG).)
-
-# Determine the timezone across various platforms to pass into the
-# docker run operation. This operation assumes zoneinfo is within
-# the path of the file.
-TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
-
-RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
-	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
-	-e TZ="$(TIMEZONE)" \
-	-e TARGET_ARCH="$(TARGET_ARCH)" \
-	-e TARGET_OS="$(TARGET_OS)" \
-	-e TARGET_OUT="$(TARGET_OUT)" \
-	-e HUB="$(HUB)" \
-	-e TAG="$(TAG)" \
-	-v /etc/passwd:/etc/passwd:ro \
-	$(DOCKER_SOCKET_MOUNT) \
-	$(CONTAINER_OPTIONS) \
-	--mount type=bind,source="$(PWD)",destination="/work" \
-	--mount type=volume,source=go,destination="/go" \
-	--mount type=volume,source=gocache,destination="/gocache" \
-	-w /work $(IMG)
+export IMG
+$(info Building with the build container: $(IMG))
+RUN = ./common/scripts/run-docker.sh
 else
 $(info Building with your local toolchain.)
 RUN =
@@ -90,10 +41,25 @@ endif
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 
+# If these variables are defined in the overrides, exporting them adds them to
+# the environment of the sub-make
+export TARGET_ARCH
+export TARGET_OS
+export TARGET_OUT
+export CONTAINER_CLI
+export DOCKER_SOCKET_MOUNT
+export CONTAINER_OPTIONS
+export TZ
+export HUB
+export TAG
+
 %:
 	@$(MAKE) $@
 
 default:
 	@$(MAKE)
+
+shell:
+	@$(RUN) /bin/bash
 
 .PHONY: default

--- a/files/Makefile
+++ b/files/Makefile
@@ -29,8 +29,6 @@
 export BUILD_WITH_CONTAINER ?= 0
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
-IMG ?= gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
-export IMG
 $(info Building with the build container: $(IMG))
 RUN = ./common/scripts/run-docker.sh
 else

--- a/files/common/scripts/run-docker.sh
+++ b/files/common/scripts/run-docker.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set -ex
+
+local_arch=$(uname -m)
+if [[ $local_arch == x86_64 ]]; then
+    target_arch=amd64
+elif [[ $local_arch == armv8* ]]; then
+    target_arch=arm64
+elif [[ $local_arch == armv* ]]; then
+    target_arch=arm
+else
+    echo "This system's architecture, $local_arch, isn't supported"
+    exit 1
+fi
+
+local_os=$(uname)
+if [[ $local_os == Linux ]]; then
+    target_os=linux
+    readlink_flags="-f"
+elif [[ $local_os == Darwin ]]; then
+    target_os=darwin
+    readlink_flags=""
+else
+    echo "This system's OS, $local_os, isn't supported"
+    exit 1
+fi
+
+timezone=$(readlink $readlink_flags /etc/localtime | sed -e 's/^.*zoneinfo\///')
+
+out="${TARGET_OUT:/work/out/${target_arch}_${target_os}}"
+
+image="${IMG:-gcr.io/istio-testing/build-tools:latest}"
+
+container_cli="${CONTAINER_CLI:-docker}"
+
+$container_cli pull "$image"
+
+# $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
+# following command only
+# shellcheck disable=SC2086
+$container_cli run -it --rm -u "$(id -u):docker" \
+    --sig-proxy=true \
+    ${DOCKER_SOCKET_MOUNT:+"-v /var/run/docker.sock:/var/run/docker.sock"} \
+    -v /etc/passwd:/etc/passwd:ro \
+    $CONTAINER_OPTIONS \
+    -e IN_BUILD_CONTAINER=1 \
+    -e TZ="${timezone:-$TZ}" \
+    -e TARGET_ARCH="${TARGET_ARCH:-$target_arch}" \
+    -e TARGET_OS="${TARGET_OS:-$target_os}" \
+    -e TARGET_OUT="$out" \
+    -e HUB="$HUB" \
+    -e TAG="$TAG" \
+    --mount "type=bind,source=$(pwd),destination=/work" \
+    --mount "type=volume,source=go,destination=/go" \
+    --mount "type=volume,source=gocache,destination=/gocache" \
+    -w /work "$image" "$@"
+


### PR DESCRIPTION
Also adds make shell to drop the user to a bash prompt within the
container.

resolves istio/istio#17476 - all commands arguments to run-docker.sh are passed
into the container

resolves istio/istio#17474 - the script will pass along a filtered picture of the host's environment to the container

Notable changes and omissions:

* When the script is run in isolation, it uses the `latest` tag of
build-tools, the makefile overrides it with the dated tag. Hopefully
someone's in charge of keeping that up to date.
~~* I left off --sig-proxy=true which helps istio/istio#17476, but does not resolve
it fully. I believe it was causing problems because the entrypoint is
PID 1 which has some special rules for SIGINTs.~~ _I was incorrect here, it's added back in_