### PR TITLE
adding required dependency to whitelist

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -96,6 +96,7 @@ whitelisted_modules:
   - github.com/juju/loggo
   - github.com/juju/testing
   - github.com/julienschmidt/httprouter
+  - github.com/koneu/natend
   - github.com/kr/logfmt
   - github.com/libopenstorage/openstorage
   - github.com/logrusorgru/aurora


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

github.com/koneu/natend is required in cni repo for nftables implementation, since this package does not have known license, adding it to the whitelist.