### PR TITLE
Pass $HUB and $TAG to the docker container

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -73,6 +73,8 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \
 	-e TARGET_OUT="$(TARGET_OUT)" \
+	-e HUB="$(HUB)" \
+	-e TAG="$(TAG)" \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \


### PR DESCRIPTION
Docker does not pass unsolicited environment variables to the
running container. This makes perfect sense, but requires overrides
of any build specific environment variables.

A better approach is being worked on (I believe) here:

https://github.com/istio/common-files/pull/94