### PR TITLE
Makefile updates.

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -56,7 +56,7 @@ ifeq ($(BUILD_WITH_CONTAINER),1)
 export TARGET_OUT = /work/out/$(TARGET_ARCH)_$(TARGET_OS)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
+IMG ?= gcr.io/istio-testing/build-tools:2019-10-18T14-38-25
 UID = $(shell id -u)
 PWD = $(shell pwd)
 
@@ -82,11 +82,6 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
 	-w /work $(IMG)
-else
-$(info Building with your local toolchain.)
-RUN =
-GOBIN ?= $(GOPATH)/bin
-endif
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 
@@ -97,3 +92,11 @@ default:
 	@$(MAKE)
 
 .PHONY: default
+
+else
+
+$(info Building with your local toolchain.)
+GOBIN ?= $(GOPATH)/bin
+include Makefile.core.mk
+
+endif

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -80,19 +80,24 @@ dump-licenses-csv:
 	@go mod download
 	@license-lint --config common/config/license-lint.yml --csv
 
+TMP := $(shell mktemp -d -u)
+UPDATE_BRANCH ?= "master"
+
 update-common:
-	@git clone -q --depth 1 --single-branch --branch master https://github.com/istio/common-files
-	@cd common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
+	@mkdir -p $(TMP)
+	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/istio/common-files $(TMP)/common-files
+	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
-	@cp -rT common-files/files .
-	@rm -fr common-files
+	@cp -rT $(TMP)/common-files/files $(pwd)
+	@rm -fr $(TMP)/common-files
 
 update-common-protos:
-	@git clone -q --depth 1 --single-branch --branch master https://github.com/istio/common-files
-	@cd common-files ; git rev-parse HEAD > common-protos/.commonfiles.sha
+	@mkdir -p $(TMP)
+	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/istio/common-files $(TMP)/common-files
+	@cd $(TMP)/common-files ; git rev-parse HEAD > common-protos/.commonfiles.sha
 	@rm -fr common-protos
-	@cp -ar common-files/common-protos common-protos
-	@rm -fr common-files
+	@cp -ar $(TMP)/common-files/common-protos $(pwd)/common-protos
+	@rm -fr $(TMP)/common-files
 
 check-clean-repo:
 	@common/scripts/check_clean_repo.sh


### PR DESCRIPTION
- Use latest container image.

- Make the branch fetched by update-common and update-common-protos 
be configurable.

- Make update-common and update-common-protos use a temp directory to clone the
common-files repo so as to not temporarily pollute the destination repo and confuse
my IDE in the process.

- Simplify how the non-container case is handled. Instead of recursively
invoking make, just include Makefile.core.mk.