### PR TITLE
Rationalize docker config for docker.push

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -68,6 +68,19 @@ $(info Building with the build container: $(IMG).)
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
+# Determine the docker.push credential bind mounts.
+# Docker and GCR are supported credentials. At this time docker.push may
+# not work well on Docker-For-Mac. This will be handled in a follow-up PR.
+DOCKER_CREDS_MOUNT:=
+ifneq (,$(wildcard $(HOME)/.docker))
+$(info Using docker credential directory $(HOME)/.docker.)
+DOCKER_CREDS_MOUNT+=--mount type=bind,source="$(HOME)/.docker",destination="/config/.docker",readonly
+endif
+ifneq (,$(wildcard $(HOME)/.config/gcloud))
+$(info Using gcr credential directory $(HOME)/.config/gcloud.)
+DOCKER_CREDS_MOUNT+=--mount type=bind,source="$(HOME)/.config/gcloud",destination="/config/.config/gcloud",readonly
+endif
+
 RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
@@ -82,8 +95,7 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
-	--mount type=bind,source="$(HOME)/.docker",destination="/config/.docker" \
-	--mount type=bind,source="$(HOME)/.config/gcloud",destination="/config/.config/gcloud" \
+	$(DOCKER_CREDS_MOUNT) \
 	-w /work $(IMG)
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk

--- a/files/Makefile
+++ b/files/Makefile
@@ -56,7 +56,7 @@ ifeq ($(BUILD_WITH_CONTAINER),1)
 export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-10-18T14-38-25
+IMG ?= gcr.io/istio-testing/build-tools:2019-10-22T04-14-16
 UID = $(shell id -u)
 GID = `grep docker /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)

--- a/files/Makefile
+++ b/files/Makefile
@@ -58,6 +58,7 @@ CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:2019-10-18T14-38-25
 UID = $(shell id -u)
+GID = `grep docker /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)
 
 $(info Building with the build container: $(IMG).)
@@ -67,7 +68,7 @@ $(info Building with the build container: $(IMG).)
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
-RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
+RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
@@ -81,6 +82,8 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
+	--mount type=bind,source="$(HOME)/.docker",destination="/config/.docker" \
+	--mount type=bind,source="$(HOME)/.config/gcloud",destination="/config/.config/gcloud" \
 	-w /work $(IMG)
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk


### PR DESCRIPTION
Enable `docker.push` in the various makefiles used in the common-files
implementation.