### PR TITLE
Fix a recent update to common files that breaks updates

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -88,7 +88,7 @@ update-common:
 	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/istio/common-files $(TMP)/common-files
 	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
-	@cp -rT $(TMP)/common-files/files $(pwd)
+	@cp -rT $(TMP)/common-files/files $(shell pwd)
 	@rm -fr $(TMP)/common-files
 
 update-common-protos:
@@ -96,7 +96,7 @@ update-common-protos:
 	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/istio/common-files $(TMP)/common-files
 	@cd $(TMP)/common-files ; git rev-parse HEAD > common-protos/.commonfiles.sha
 	@rm -fr common-protos
-	@cp -ar $(TMP)/common-files/common-protos $(pwd)/common-protos
+	@cp -ar $(TMP)/common-files/common-protos $(shell pwd)/common-protos
 	@rm -fr $(TMP)/common-files
 
 check-clean-repo:


### PR DESCRIPTION
`make update-common` fails with master of common-files if run
after a repository has been updated. Fix that problem.