### PR TITLE
Only pass environment variables that are set

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -81,14 +81,21 @@ $(info Using gcr credential directory $(HOME)/.config/gcloud.)
 DOCKER_CREDS_MOUNT+=--mount type=bind,source="$(HOME)/.config/gcloud",destination="/config/.config/gcloud",readonly
 endif
 
+ENV_VARS:=
+ifdef HUB
+ENV_VARS+=-e HUB="$(HUB)"
+endif
+ifdef TAG
+ENV_VARS+=-e TAG="$(TAG)"
+endif
+
 RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \
 	-e TARGET_OUT="$(TARGET_OUT)" \
-	-e HUB="$(HUB)" \
-	-e TAG="$(TAG)" \
+	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \


### PR DESCRIPTION
Before this change, if HUB or TAG as was not set, we set them to ""
which breaks istio/istio. We should only pass them if they are set.