### PR TITLE
Only pass environment variables that are set (#133)

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -67,14 +67,21 @@ $(info Building with the build container: $(IMG).)
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
+ENV_VARS:=
+ifdef HUB
+ENV_VARS+=-e HUB="$(HUB)"
+endif
+ifdef TAG
+ENV_VARS+=-e TAG="$(TAG)"
+endif
+
 RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \
 	-e TARGET_OUT="$(TARGET_OUT)" \
-	-e HUB="$(HUB)" \
-	-e TAG="$(TAG)" \
+	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \


### PR DESCRIPTION
Before this change, if HUB or TAG as was not set, we set them to ""
which breaks istio/istio. We should only pass them if they are set.

(cherry picked from commit 1f13b409902afaa2a6c578e9f98a80875a3091b5)