### PR TITLE
Add option to use proxy builder image

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -57,6 +57,9 @@ export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+ifeq ($(shell basename $(shell pwd)),proxy)
+IMG = gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
+endif
 UID = $(shell id -u)
 GID = `grep docker /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)
@@ -95,6 +98,7 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \
 	-e TARGET_OUT="$(TARGET_OUT)" \
+	-e USER="${USER}" \
 	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \

--- a/files/Makefile
+++ b/files/Makefile
@@ -57,9 +57,6 @@ export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
-ifeq ($(shell basename $(shell pwd)),proxy)
-IMG = gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
-endif
 UID = $(shell id -u)
 GID = `grep docker /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)


### PR DESCRIPTION
Change build to use proxy build-tools when path basename is `proxy`. Also add USER env variable to docker run, which is needed by proxy build.