### PR TITLE
Set default hub

### DIFF
--- a/files/common/scripts/report_build_info.sh
+++ b/files/common/scripts/report_build_info.sh
@@ -43,7 +43,7 @@ if [[ -n ${ISTIO_VERSION} ]]; then
 fi
 
 GIT_DESCRIBE_TAG=$(git describe --tags)
-HUB=${HUB:-""}
+HUB=${HUB:-"docker.io"}
 
 # used by common/scripts/gobuild.sh
 echo "istio.io/pkg/version.buildVersion=${VERSION}"


### PR DESCRIPTION
Otherwise if you set just the version but not the hub things break. Specifically Homebrew istioctl is broken. They should fix it, but we should make it easier to build anyways