### PR TITLE
Fix Makefile bugs on Arm64 platform

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -31,7 +31,7 @@ export BUILD_WITH_CONTAINER ?= 0
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
+else ifeq ($(LOCAL_ARCH),aarch64)
     TARGET_ARCH ?= arm64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm


### PR DESCRIPTION
The command `uname -m` on arm64 platform return the
value 'aarch64', but not arm64.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>