### PR TITLE
Add aarch64 support in files/Makefile

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -33,6 +33,8 @@ ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
     TARGET_ARCH ?= arm64
+else ifeq ($(LOCAL_ARCH),aarch64)
+    TARGET_ARCH ?= arm64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm
 else


### PR DESCRIPTION
In files/Makefile, the aarch64 does not well supportted by Istio.
In this patch, aarch64 option is added in files/Makefile.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>