### PR TITLE
Fix default hub

### DIFF
--- a/files/common/scripts/report_build_info.sh
+++ b/files/common/scripts/report_build_info.sh
@@ -43,7 +43,7 @@ if [[ -n ${ISTIO_VERSION} ]]; then
 fi
 
 GIT_DESCRIBE_TAG=$(git describe --tags)
-HUB=${HUB:-"docker.io"}
+HUB=${HUB:-"docker.io/istio"}
 
 # used by common/scripts/gobuild.sh
 echo "istio.io/pkg/version.buildVersion=${VERSION}"


### PR DESCRIPTION
Before it was not right, would result in images like `docker.io/pilot:tag`