### PR TITLE
Add a TARGET_OUT_LINUX environment variable

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -53,9 +53,11 @@ else
 endif
 
 export TARGET_OUT ?= $(shell pwd)/out/$(TARGET_OS)_$(TARGET_ARCH)
+export TARGET_OUT_LINUX ?= $(shell pwd)/out/linux_amd64
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
 export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
+export TARGET_OUT_LINUX = /work/out/linux_amd64
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:master-2019-12-05T22-22-12
@@ -104,6 +106,7 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
 	-e TARGET_OS="$(TARGET_OS)" \
 	-e TARGET_OUT="$(TARGET_OUT)" \
+	-e TARGET_OUT_LINUX="$(TARGET_OUT_LINUX)" \
 	-e USER="${USER}" \
 	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \


### PR DESCRIPTION
TARGET_OUT_LINUX is the container version of TARGET_OUT. If cross-compiling (on MacOS as an example), TARGET_OUT_LINUX indicates where to put Linux binaries. /gobin could be used, however, MacOS is pokey and the caching of the build seems necessary.

One future improvement is to create a volume mount for internal binaries and set TARGET_OUT_LINUX to the volume mount location. We can't use `/gobin` for this location, as `/gobin` contains a bunch of binaries from the container itself. it might be possible to use a shared mount - would need more R&D.