### PR TITLE
Fixed the Istio docker build failure

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -108,17 +108,15 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_OUT="$(TARGET_OUT)" \
 	-e TARGET_OUT_LINUX="$(TARGET_OUT_LINUX)" \
 	-e USER="${USER}" \
-	-e GOPATH="/work" \
-	-e GOBIN="/work/bin" \
 	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
-	--mount type=bind,source="$(GOPATH)",destination="/work" \
+	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
 	$(CONDITIONAL_HOST_MOUNTS) \
-	-w /work/src/istio.io/istio $(IMG)
+	-w /work $(IMG)
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 

--- a/files/Makefile
+++ b/files/Makefile
@@ -28,7 +28,7 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
-# This is the "go test" options
+# This is the "go test" options.
 export T ?= "--timeout=100s"
 
 LOCAL_ARCH := $(shell uname -m)

--- a/files/Makefile
+++ b/files/Makefile
@@ -29,7 +29,7 @@
 export BUILD_WITH_CONTAINER ?= 0
 
 # This is the "go test" options.
-export T ?= "--timeout=100s"
+export T ?= ""
 
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)

--- a/files/Makefile
+++ b/files/Makefile
@@ -59,8 +59,8 @@ export TARGET_OUT ?= $(shell pwd)/out/$(TARGET_OS)_$(TARGET_ARCH)
 export TARGET_OUT_LINUX ?= $(shell pwd)/out/linux_amd64
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
-export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
-export TARGET_OUT_LINUX = /work/out/linux_amd64
+export TARGET_OUT = /work/src/istio.io/istio/out/$(TARGET_OS)_$(TARGET_ARCH)
+export TARGET_OUT_LINUX = /work/src/istio.io/istio/out/linux_amd64
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
@@ -112,13 +112,12 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_OUT_LINUX="$(TARGET_OUT_LINUX)" \
 	-e USER="${USER}" \
 	-e T="${T}" \
-	-e GOPATH="/work" \
-	-e GOBIN="/work/bin" \
+	-e GOBIN="/work/src/istio.io/istio/bin" \
 	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
-	--mount type=bind,source="$(GOPATH)",destination="/work" \
+	--mount type=bind,source="$(PWD)",destination="/work/src/istio.io/istio" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
 	$(CONDITIONAL_HOST_MOUNTS) \

--- a/files/Makefile
+++ b/files/Makefile
@@ -108,15 +108,17 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_OUT="$(TARGET_OUT)" \
 	-e TARGET_OUT_LINUX="$(TARGET_OUT_LINUX)" \
 	-e USER="${USER}" \
+	-e GOPATH="/work" \
+	-e GOBIN="/work/bin" \
 	$(ENV_VARS) \
 	-v /etc/passwd:/etc/passwd:ro \
 	$(DOCKER_SOCKET_MOUNT) \
 	$(CONTAINER_OPTIONS) \
-	--mount type=bind,source="$(PWD)",destination="/work" \
+	--mount type=bind,source="$(GOPATH)",destination="/work" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
 	$(CONDITIONAL_HOST_MOUNTS) \
-	-w /work $(IMG)
+	-w /work/src/istio.io/istio $(IMG)
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 

--- a/files/Makefile
+++ b/files/Makefile
@@ -28,8 +28,8 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
-# This is the "go test" options.
-export T ?= ""
+# This is the "go test" options. Default empty value.
+export T ?=
 
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)

--- a/files/Makefile
+++ b/files/Makefile
@@ -28,6 +28,9 @@
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
+# This is the "go test" options
+export T ?= "--timeout=100s"
+
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
@@ -108,6 +111,7 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e TARGET_OUT="$(TARGET_OUT)" \
 	-e TARGET_OUT_LINUX="$(TARGET_OUT_LINUX)" \
 	-e USER="${USER}" \
+	-e T="${T}" \
 	-e GOPATH="/work" \
 	-e GOBIN="/work/bin" \
 	$(ENV_VARS) \


### PR DESCRIPTION
This PR includes:
✔ Fixed corrupted docker building procedure in Istio component.
✔ Enable "go test" options by setting environment variable $T which is already existed in "Makefile.core.mk"

I'll explain this in details:
👉 I've made the "current directory" mapped to  "/work/src/istio.io/istio" because some legacy tests in Istio need path "/src/istio.io/istio" to find the source root. This doesn't affect the final outputs and behaves exactly like "building with local tool chain".
👉 Added the missing "GOBIN" environment variable (Otherwise it will become "/gobin" in building process which will cause test failure).