### PR TITLE
Add a `make tidy-docker` make target

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -113,6 +113,6 @@ check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
 tidy-docker:
-	@docker images | grep gcr.io/istio-testing/build-tools | while read c1 c2 c3; do docker rmi -f $c1:$c2; done
+	@docker images | grep gcr.io/istio-testing/build-tools | while read c1 c2 c3; do docker rmi -f $$c1:$$c2; done
 
 .PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -113,6 +113,6 @@ check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
 tidy-docker:
-	@docker images | grep gcr.io/istio-testing/build-tools | while read c1 c2 c3; do docker rmi -f $$c1:$$c2; done
+	docker rmi $$(docker images --filter=reference="gcr.io/istio-testing/build-tools" --filter=reference="gcr.io/istio-testing/build-tools-proxy" -q)
 
 .PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -112,4 +112,7 @@ update-common-protos:
 check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
-.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo
+tidy-docker:
+	@docker images | grep gcr.io/istio-testing/build-tools | while read c1 c2 c3; do docker rmi -f $c1:$c2; done
+
+.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker


### PR DESCRIPTION
As we revise the build-tools image, old images are cached and left
behind. `make tidy-docker` prunes docker stuff that we may not want
to persist when developer systems start to experience disk pressure.