### PR TITLE
Add make `tidy-docker` to clean up build-tools

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -113,7 +113,7 @@ check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
 tidy-docker:
-	@docker image prune --all --force --filter="label=com.istio.io.repo=https://github.com/istio/tools" --filter="label!=com.istio.io.version=$(IMAGE_VERSION)"
+	@docker image prune --all --force --filter="label=io.istio.repo=https://github.com/istio/tools" --filter="label!=io.istio.version=$(IMAGE_VERSION)"
 
 
 .PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -112,4 +112,8 @@ update-common-protos:
 check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
-.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo
+tidy-docker:
+	@docker image prune --all --force --filter="label=com.istio.io.repo=https://github.com/istio/tools" --filter="label!=com.istio.io.version=$(IMAGE_VERSION)"
+
+
+.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker


### PR DESCRIPTION
This cleans up build-tools images, minus the one in use. Please be
aware that build iamges on your system prior to the labeling of
the build-tools container will require manual removal.