### PR TITLE
fix get gid

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -65,7 +65,7 @@ CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
 IMG ?= gcr.io/istio-testing/build-tools:$(IMAGE_VERSION)
 UID = $(shell id -u)
-GID = `grep docker /etc/group | cut -f3 -d:`
+GID = `grep '^docker:' /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)
 
 $(info Building with the build container: $(IMG).)


### PR DESCRIPTION
GID = grep docker /etc/group | cut -f3 -d:
should be
GID = grep '^docker:' /etc/group | cut -f3 -d:

match for the docker group precise for local build。