### PR TITLE
Fix for yaml-lint

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 # allow optional per-repo overrides
 -include Makefile.overrides.mk
 
@@ -29,7 +31,7 @@
 export BUILD_WITH_CONTAINER ?= 0
 
 # Version of image used within build container
-IMAGE_VERSION ?= master-2020-02-14T13-09-14
+IMAGE_VERSION ?= master-2020-03-04T04-41-33
 
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -28,8 +28,9 @@ lint-dockerfiles:
 lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
 
+# TODO(nmittler): disabled pipefail due to grep failing when no files contain "{{". Need to investigate options.
 lint-yaml:
-	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" | xargs -r yamllint -c ./common/config/.yamllint.yml
+	@set +o pipefail; @${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" | xargs -r yamllint -c ./common/config/.yamllint.yml
 
 lint-helm:
 	@${FINDFILES} -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict


### PR DESCRIPTION
yaml lint breaks on istio.io when -o pipefail is set. This is due to the fact that grep fails when it find no files containing templates "{{". This is a workaround to fix the istio.io build.