### PR TITLE
Add s390x support

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -42,6 +42,8 @@ else ifeq ($(LOCAL_ARCH),aarch64)
     TARGET_ARCH ?= arm64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm
+else ifeq ($(LOCAL_ARCH),s390x)
+    TARGET_ARCH ?= s390x
 else
     $(error This system's architecture $(LOCAL_ARCH) isn't supported)
 endif


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for the s390x architecture (aka [IBM Z](https://en.wikipedia.org/wiki/IBM_Z)).

**Which issue this PR fixes**: None

**Special notes for your reviewer**: envoy does not build on s390x yet, but we are sending PRs to fix this.