### PR TITLE
configurable image name (IMAGE_NAME) via environment

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -30,6 +30,9 @@ SHELL := /bin/bash
 # figure out all the tools you need in your environment to make that work.
 export BUILD_WITH_CONTAINER ?= 0
 
+# Name of build container image
+IMAGE_NAME ?= build-tools
+
 # Version of image used within build container
 IMAGE_VERSION ?= master-2020-03-05T18-27-04
 
@@ -65,7 +68,7 @@ export TARGET_OUT = /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 export TARGET_OUT_LINUX = /work/out/linux_amd64
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:$(IMAGE_VERSION)
+IMG ?= gcr.io/istio-testing/$(IMAGE_NAME):$(IMAGE_VERSION)
 UID = $(shell id -u)
 GID = `grep '^docker:' /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)


### PR DESCRIPTION
This will allow the **istio/proxy** repo to only need an override on the _image name_ (i.e. `IMAGE_NAME`) in Makefile. The benefit is that `make update-common` will work for it without manual edits. Moreover, it will allow the automator (see: https://github.com/istio/test-infra/pull/2384) to do the common-files update and build-tools image bump automatically (and consistently) like it does for other **istio/*** repos.


> corresponding **istio/proxy** change: https://github.com/istio/proxy/pull/2755