### PR TITLE
common .gitignore file

### DIFF
--- a/files/common/config/.gitignore_common
+++ b/files/common/config/.gitignore_common
@@ -1,0 +1,2 @@
+# Contains built artifacts
+out/

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -51,6 +51,9 @@ else
     exit 1
 fi
 
+# Setup common .gitignore
+git config --local core.excludesfile ./common/config/.gitignore_common
+
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
   export IMAGE_VERSION=master-2020-03-05T18-27-04


### PR DESCRIPTION
Support ignoring specific files/dirs when using `make` (e.g. `make check-clean-repo`):

* https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_gogo-genproto/46/gencheck_gogo-genproto/25
* https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_pkg/122/gencheck_pkg/60
* ...