### PR TITLE
remove yaml-lint hack

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -28,9 +28,8 @@ lint-dockerfiles:
 lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
 
-# TODO(nmittler): disabled pipefail due to grep failing when no files contain "{{". Need to investigate options.
 lint-yaml:
-	@set +o pipefail; @${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" | xargs -r yamllint -c ./common/config/.yamllint.yml
+	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" || true | xargs -r yamllint -c ./common/config/.yamllint.yml
 
 lint-helm:
 	@${FINDFILES} -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict


### PR DESCRIPTION
fix: https://github.com/istio/istio/issues/21854

Adding the `|| true` to prevents `grep` from emitting exit status **1** when no lines were selected _and_ the subsequent `xargs` call from emitting **123** b/c the previous command (i.e `grep`) emitted a exit status between **1-125**. 

> see `man bash`, `man grep` and `man xargs` for details.

**Before:**
```console
$ BUILD_WITH_CONTAINER=1 make lint-yaml ; echo $?
/bin/bash: @find: command not found
0
```
**After:**
```console
$ BUILD_WITH_CONTAINER=1 make lint-yaml ; echo $?
...
./pkg/kube/inject/testdata/inject/deploymentconfig.yaml
./pkg/kube/inject/testdata/inject/enable-core-dump.yaml
0
```