### PR TITLE
Remove functions from the list of exported variables

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -78,6 +78,12 @@ export CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 
 export ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|PATH\|SHELL\|EDITOR\|TMUX\|USER\|HOME\|PWD\|TERM\|GO\|rvm\|SSH\|TMPDIR}"
 
+# Remove functions from the list of exported variables, they mess up with the `env` command.
+for f in $(declare -F -x | cut -d ' ' -f 3);
+do
+  unset -f "${f}"
+done
+
 # Set up conditional host mounts for docker and kubernetes config
 export CONDITIONAL_HOST_MOUNTS=${CONDITIONAL_HOST_MOUNTS:-}
 if [[ -d "${HOME}/.docker" ]]; then


### PR DESCRIPTION
Some enviroments might have functions exported (with
their multi-line body) as global variables, and the `env`
command will print them, breaking the `--env-file` option
of our docker run command.

So, we must get rid of them before invoking `env`.