### PR TITLE
Fix recursive make

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -40,13 +40,13 @@ $(shell $(shell pwd)/common/scripts/setup_env.sh)
 
 RUN = ./common/scripts/run.sh
 
-MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
+MAKE_DOCKER = $(RUN) $(MAKE) --no-print-directory -e -f Makefile.core.mk
 
 %:
-	@$(MAKE) $@
+	@$(MAKE_DOCKER) $@
 
 default:
-	@$(MAKE)
+	@$(MAKE_DOCKER)
 
 shell:
 	@$(RUN) /bin/bash

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -96,6 +96,9 @@ if [[ -d "${HOME}/.kube" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube "
 fi
 
+# Avoid recursive calls to make from attempting to start an additional container
+export BUILD_WITH_CONTAINER=0
+
 # For non container build, we need to write env to file
 if [[ "${1}" == "envfile" ]]; then
   echo "TARGET_OUT_LINUX=${TARGET_OUT_LINUX}"
@@ -105,4 +108,5 @@ if [[ "${1}" == "envfile" ]]; then
   echo "TARGET_OS=${TARGET_OS}"
   echo "LOCAL_ARCH=${LOCAL_ARCH}"
   echo "TARGET_ARCH=${TARGET_ARCH}"
+  echo "BUILD_WITH_CONTAINER=0"
 fi


### PR DESCRIPTION
Currently any targets calling make are broken because it tries to do
docker multiple layers in. This makes it so once we are in the docker
container, we don't try to go into another docker container.