### PR TITLE
Add check-no-modify target to prevent some files from being modified

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -113,6 +113,9 @@ update-common-protos:
 check-clean-repo:
 	@common/scripts/check_clean_repo.sh
 
+check-no-modify:
+	@common/scripts/check_no_modify.sh
+
 tidy-docker:
 	@docker image prune --all --force --filter="label=io.istio.repo=https://github.com/istio/tools" --filter="label!=io.istio.version=$(IMAGE_VERSION)"
 

--- a/files/common/scripts/check_no_modify.sh
+++ b/files/common/scripts/check_no_modify.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MD5FILE="${SCRIPT_DIR}/nomodify.md5"
+
+md5sum -c  "${MD5FILE}"|| echo "Files in ${MD5FILE} should not be modified in the repo. Please remove the change from your PR."

--- a/files/common/scripts/nomodify.md5
+++ b/files/common/scripts/nomodify.md5
@@ -1,0 +1,1 @@
+cf4ad6158a6c85157286f3f17bbc7e9e  ../../operator/pkg/vfs/assets.gen.go


### PR DESCRIPTION
assets.gen.go should not be updated in the repo after it is locally generated. This target supports testing this in a precommit check.