### PR TITLE
Set up the conditional mounts correctly

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -90,16 +90,25 @@ do
   unset -f "${f}"
 done
 
-# Set up conditional host mounts for docker and kubernetes config
+# Set conditional host mounts
 export CONDITIONAL_HOST_MOUNTS=${CONDITIONAL_HOST_MOUNTS:-}
+
+# docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly "
 fi
+
+# gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
 if [[ -d "${HOME}/.config/gcloud" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly "
 fi
-if [[ -d "${HOME}/.kube" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube "
+
+# Conditional host mount if KUBECONFIG is set
+if [[ -n "${KUBECONFIG}" ]]; then
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=$(dirname "${KUBECONFIG}"),destination=/home/.kube,readonly "
+elif [[ -f "${HOME}/.kube/config" ]]; then
+  # otherwise execute a conditional host mount if $HOME/.kube/config is set
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube,readonly "
 fi
 
 # Avoid recursive calls to make from attempting to start an additional container


### PR DESCRIPTION
In prior implementations, there has always been a confusion between
what exactly $HOME is.
There are three variants of $HOME experienced in the field:
1. $HOME set to /home
1. $HOME set to /home/sdake
1. $HOME set to /Users/sdake

Not all of these conditions were properly managed. This PR handles the
three conditions above.

Related: https://github.com/istio/istio/pull/23293/