### PR TITLE
Whitelist licenses unrecognized by new go license checker

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -199,3 +199,12 @@ whitelisted_modules:
 
   # Apache 2.0: https://github.com/garyburd/redigo/blob/master/LICENSE
   - github.com/gomodule/redigo
+
+  # Apache 2.0: https://github.com/xdg-go/scram/blob/master/LICENSE
+  - github.com/xdg-go/scram
+
+  # Apache 2.0: https://github.com/xdg-go/stringprep/blob/master/LICENSE
+  - github.com/xdg/stringprep
+
+  # BSD-3: https://github.com/golang/tools/blob/master/LICENSE
+  - golang.org/x/tools


### PR DESCRIPTION
These licenses are no longer recognized/detected after: istio/tools#867. This PR includes additional whitelisting missing from: https://github.com/istio/common-files/pull/225


https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_bots/180/lint_bots/191
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_test-infra/2628/lint_test-infra/2426