### PR TITLE
Use legacy org for "github.com/xdg/scram" module

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -200,10 +200,10 @@ whitelisted_modules:
   # Apache 2.0: https://github.com/garyburd/redigo/blob/master/LICENSE
   - github.com/gomodule/redigo
 
-  # Apache 2.0: https://github.com/xdg-go/scram/blob/master/LICENSE
-  - github.com/xdg-go/scram
+  # Apache 2.0: https://github.com/xdg/scram/blob/master/LICENSE
+  - github.com/xdg/scram
 
-  # Apache 2.0: https://github.com/xdg-go/stringprep/blob/master/LICENSE
+  # Apache 2.0: https://github.com/xdg/stringprep/blob/master/LICENSE
   - github.com/xdg/stringprep
 
   # BSD-3: https://github.com/golang/tools/blob/master/LICENSE


### PR DESCRIPTION
While both `github.com/xdg/scram` and `github.com/xdg-go/scram` are the same module, the module is declared as the former in the module graph.
