### PR TITLE
Relax consistency in the development environment

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -47,8 +47,8 @@ export REPO_ROOT=/work
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
     -e IN_BUILD_CONTAINER=1 \
     -e TZ="${TIMEZONE:-$TZ}" \
-    --mount "type=bind,source=${PWD},destination=/work" \
-    --mount "type=volume,source=go,destination=/go" \
-    --mount "type=volume,source=gocache,destination=/gocache" \
+    --mount "type=bind,source=${PWD},destination=/work,consistency=delegated" \
+    --mount "type=volume,source=go,destination=/go,consistency=delegated" \
+    --mount "type=volume,source=gocache,destination=/gocache,consistency=delegated" \
     ${CONDITIONAL_HOST_MOUNTS} \
     -w /work "${IMG}" "$@"

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -95,20 +95,20 @@ export CONDITIONAL_HOST_MOUNTS=${CONDITIONAL_HOST_MOUNTS:-}
 
 # docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly,consistency=delegated "
 fi
 
 # gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
 if [[ -d "${HOME}/.config/gcloud" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly,consistency=delegated "
 fi
 
 # Conditional host mount if KUBECONFIG is set
 if [[ -n "${KUBECONFIG}" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=$(dirname "${KUBECONFIG}"),destination=/home/.kube,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=$(dirname "${KUBECONFIG}"),destination=/home/.kube,readonly,consistency=delegated "
 elif [[ -f "${HOME}/.kube/config" ]]; then
   # otherwise execute a conditional host mount if $HOME/.kube/config is set
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube,readonly,consistency=delegated "
 fi
 
 # Avoid recursive calls to make from attempting to start an additional container


### PR DESCRIPTION
For dockerd to maintain consistency in teh bind mounts on Linux machines,
its relatively easy to achieve this result just by using native Linux
interfaces.

On MacOS, Docker has to do **ALOT** more work to maintain filesystem
consistency. I use the following definition: A write to a shared mount
from either the development environment or within the container will be
 read exactly as it was written, instead of potentially returning old data
on a read.

If the consistency is relaxed (I am talking a few hundred milliseconds at
most), Docker for Mac performs much better with minimal to no noticable
impact. I would like to trial this PR in 1.7. If it becomes a problem,
it is easy enough to revert.

Some (unofficial) benchmarks:

 Freshly installed MacOS on 2020 Mac 13" with 32gb 3733 LPDDR4, 1TB hd, 2.3 GHZ Quad Core Intel core I7 lightly loaded running on wall power.

Docker is configured as:
6 CPUs, 8GB ram, 1gig swap setup for Docker for  Mac, running K8s

| with PR | cached | benchmark command | wall-clock (s) |
| --- | --- | --- | --- |
| YES | NO | gtime -f %e make clean | 1.53
| YES | NO | gtime -f %e make build | 48.54
| YES | NO | gtime -f %e make docker | 68.49
| YES | YES | gtime -f %e make build | 9.45
| YES | YES | gtime -f %e make docker | 40.04
| NO | NO | gtime -f %e make clean | 2.23
| NO | NO | gtime -f %e make build | 53.20
| NO | NO | gtime -f %e make docker | 91.86
| NO | YES | gtime -f %e make build | 23.07
| NO | YES | gtime -f %e make docker | 59.15