### PR TITLE
All of our dockerfiles ignore DL3008

### DIFF
--- a/files/common/config/.hadolint.yml
+++ b/files/common/config/.hadolint.yml
@@ -6,6 +6,7 @@
 # "make update-common".
 
 ignored:
+  - DL3008
 
 trustedRegistries:
   - gcr.io


### PR DESCRIPTION
I do not consider DL3008 to be a best practice. While it would be nice
to pin every single package version introduced in the distro, this is
not practical as old versions are removed from the repositories. If
we pin all versions we use, we risk a situation in which we can no
longer build.

The community appears to concur, as DL3008 is escaped in every dockerfile
where a version pin could be used.