### PR TITLE
Make signals work during build and test operations

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -37,7 +37,7 @@ export REPO_ROOT=/work
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
 # shellcheck disable=SC2086
-"${CONTAINER_CLI}" run -it --rm \
+"${CONTAINER_CLI}" run --init -it --rm \
     -u "${UID}:${DOCKER_GID}" \
     --sig-proxy=true \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \


### PR DESCRIPTION
Adding the `--init` flag causes docker to run as PID0 the binary
`docker-init`. This process reaps zombie processes and more importantly
captures signals from make and exits a container cleanly on user
prompt (ctrl-c specifically).