### PR TITLE
Only mount/add kubeconfig in build container if it exists

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -104,7 +104,7 @@ if [[ -d "${HOME}/.config/gcloud" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly,consistency=delegated "
 fi
 
-# Thus function checks if the file exists. If it does, it creates a randomly named host location
+# This function checks if the file exists. If it does, it creates a randomly named host location
 # for the file, adds it to the host KUBECONFIG, and creates a mount for it.
 add_KUBECONFIG_if_exists () {
   if [[ -f "$1" ]]; then

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -104,6 +104,16 @@ if [[ -d "${HOME}/.config/gcloud" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly,consistency=delegated "
 fi
 
+# Thus function checks if the file exists. If it does, it creates a randomly named host location
+# for the file, adds it to the host KUBECONFIG, and creates a mount for it.
+add_KUBECONFIG_if_exists () {
+  if [[ -f "$1" ]]; then
+    kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
+    container_kubeconfig+="/home/${kubeconfig_random}:"
+    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+  fi
+}
+
 # This function is designed for maximum compatibility with various platforms. This runs on
 # any Mac or Linux platform with bash 4.2+. Please take care not to modify this function
 # without testing properly.
@@ -119,23 +129,17 @@ TMPDIR=""
 if [[ "$1" =~ ([^:]*):(.*) ]]; then
   while true; do
     rematch=${BASH_REMATCH[1]}
-    kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
-    container_kubeconfig+="/home/${kubeconfig_random}:"
-    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${rematch},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+    add_KUBECONFIG_if_exists "$rematch"
     remainder="${BASH_REMATCH[2]}"
     if [[ ! "$remainder" =~ ([^:]*):(.*) ]]; then
       if [[ -n "$remainder" ]]; then
-        kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
-        container_kubeconfig+="/home/${kubeconfig_random}:"
-        CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${remainder},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+        add_KUBECONFIG_if_exists "$remainder"
         break
       fi
     fi
   done
 else
-  kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
-  container_kubeconfig+="/home/${kubeconfig_random}:"
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+  add_KUBECONFIG_if_exists "$1"
 fi
 }
 


### PR DESCRIPTION
The reason for this change was we actually need more that Docker and make to use the build container. We actually needed a kubeconfig file (could be fake) that could be mounted in the build container. None of the developer docs talked about how to create this container and some developers, say docs, might not need to actually have a kube cluster configured. This change should allow us to go back to not requiring a kubeconfig file being available when running the build container.

I tested this by renaming my ~/.kube/config file so it wouldn't be found, and well as adding a fictitious kubeconfig file in a set of them (admittedly only at the end).
