### PR TITLE
Update .golangci.yml

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.21.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.27.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m


### PR DESCRIPTION
Updating the config file to tell golangci-lint to use the latest version 
see: https://golangci-lint.run/usage/configuration/#config-file

1.27 is already installed in the latest build-tools
```
docker run gcr.io/istio-testing/build-tools:master-2020-06-25T05-18-39 golangci-lint version
golangci-lint has version v1.27.0 built from (unknown, mod sum: "h1:VYLx63qb+XJsHdZ27PMS2w5JZacN0XG8ffUwe7yQomo=") on (unknown)
```

Keeping `do-not-merge` while testing that this won't break `make go-lint` in istio/istio