### PR TITLE
Remove delegation on readonly mounts

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -96,12 +96,12 @@ container_kubeconfig=''
 
 # docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly,consistency=delegated "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly "
 fi
 
 # gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
 if [[ -d "${HOME}/.config/gcloud" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly,consistency=delegated "
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly "
 fi
 
 # This function checks if the file exists. If it does, it creates a randomly named host location
@@ -110,7 +110,7 @@ add_KUBECONFIG_if_exists () {
   if [[ -f "$1" ]]; then
     kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
     container_kubeconfig+="/home/${kubeconfig_random}:"
-    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly "
   fi
 }
 


### PR DESCRIPTION
I noticed after moving up to the latest `edge` Docker for Mac (D4M) that my laptop would have it's fan running after I had done any Istio builds and that the Hyperkit was holding around 125-150% CPU.

Doing a little research, I see that there is a new 2-way sync, https://docs.docker.com/docker-for-mac/mutagen-caching/, in later versions of D4M. Looking at the file resources, I could see that my ~/.docker directory was in a two-way sync with lots of updates when nothing should really have been going on.

I recalled, that the Istio build does mount the docker directory and that was causing the two-way syncing to be running against the .docker directory (and I also noted against the kubeconfigs). Looking at the code, I suspect the Docker code is looking at the consistency to determine if sync'ing should be done and ignoring the readonly flag. If I remove the consistency from the .docker and kubeconfig mounts, I don't see any two-way syncing happening and the CPU settles down after the build and the fan doesn't sound like a jet.

For now, I think it makes sense for there to not be any consistency specified for the readonly mounts and removed it here.

I will write an Issue on Docker For Mac so they might ignore the sync'ing if readonly is specified.

Does this make sense @sdake?

I did note that a `make istioctl` dropped to about 20% of the time after making this change.