### PR TITLE
[release-1.6] Better handle vendored trees

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses \) -prune -o -type f
+FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses -o -path ./vendor \) -prune -o -type f
 XARGS = xargs -0 -r
 
 lint-dockerfiles:
@@ -60,14 +60,16 @@ lint-typescript:
 lint-protos:
 	@if test -d common-protos; then $(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool lint --protoc-bin-path=/usr/bin/protoc --protoc-wkt-path=common-protos; fi
 
-lint-licenses:
-	@-go mod download
+lint-licenses: mod-download-go
 	@license-lint --config common/config/license-lint.yml
 
 lint-all: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-markdown lint-sass lint-typescript lint-protos lint-licenses
 
 tidy-go:
 	@go mod tidy
+
+mod-download-go:
+	@-GOFLAGS="-mod=readonly" go mod download
 
 format-go: tidy-go
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} goimports -w -local "istio.io"
@@ -78,16 +80,13 @@ format-python:
 format-protos:
 	@$(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool format -w
 
-dump-licenses:
-	@go mod download
+dump-licenses: mod-download-go
 	@license-lint --config common/config/license-lint.yml --report
 
-dump-licenses-csv:
-	@go mod download
+dump-licenses-csv: mod-download-go
 	@license-lint --config common/config/license-lint.yml --csv
 
-mirror-licenses:
-	@go mod download
+mirror-licenses: mod-download-go
 	@rm -fr licenses
 	@license-lint --mirror
 
@@ -117,4 +116,4 @@ tidy-docker:
 	@docker image prune --all --force --filter="label=io.istio.repo=https://github.com/istio/tools" --filter="label!=io.istio.version=$(IMAGE_VERSION)"
 
 
-.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker
+.PHONY: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos lint-all format-go format-python format-protos update-common update-common-protos lint-licenses dump-licenses dump-licenses-csv check-clean-repo tidy-docker tidy-go mod-download-go


### PR DESCRIPTION
- Skip the vendor dir in `find` usages
- Create a target for running `go mod download` to be reused by other
  projects, that work on vendored trees.

Manual cherry-pick of https://github.com/istio/common-files/pull/271