### PR TITLE
Change caching to `cached` in support of new file synchronization

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -47,8 +47,8 @@ export REPO_ROOT=/work
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
     -e IN_BUILD_CONTAINER=1 \
     -e TZ="${TIMEZONE:-$TZ}" \
-    --mount "type=bind,source=${PWD},destination=/work,consistency=delegated" \
-    --mount "type=volume,source=go,destination=/go,consistency=delegated" \
-    --mount "type=volume,source=gocache,destination=/gocache,consistency=delegated" \
+    --mount "type=bind,source=${PWD},destination=/work,consistency=cached" \
+    --mount "type=volume,source=go,destination=/go,consistency=cached" \
+    --mount "type=volume,source=gocache,destination=/gocache,consistency=cached" \
     ${CONDITIONAL_HOST_MOUNTS} \
     -w /work "${IMG}" "$@"


### PR DESCRIPTION
This leaves file caching enabled in a recent PR but turns off two-way syncing on the Mac: https://docs.docker.com/docker-for-mac/mutagen/#bypassing-a-two-way-sync-for-a-volume