### PR TITLE
set common make shell to bash

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses -o -path ./vendor \) -prune -o -type f
 XARGS = xargs -0 -r
 


### PR DESCRIPTION
Previously, `make lint-yaml` in the tools repo would fail with
> /bin/sh: 1: set: Illegal option -o pipefail