### PR TITLE
Allow setting MARKDOWN_LINT_ALLOWLIST instead of _WHITELIST

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -54,8 +54,9 @@ lint-python:
 lint-markdown:
 	@${FINDFILES} -name '*.md' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb
 
+# TODO(tbarrella): clean up fallback
 lint-links:
-	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow_ssl --allow-timeout --allow-dupe --allow-redirect --white-list ${MARKDOWN_LINT_WHITELIST}
+	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow_ssl --allow-timeout --allow-dupe --allow-redirect --white-list ${MARKDOWN_LINT_ALLOWLIST:-${MARKDOWN_LINT_WHITELIST}}
 
 lint-sass:
 	@${FINDFILES} -name '*.scss' -print0 | ${XARGS} sass-lint -c common/config/sass-lint.yml --verbose


### PR DESCRIPTION
As part of https://github.com/istio/istio/issues/25381

`--white-list` can't be changed but at least we can change this variable