### PR TITLE
Revert "set common make shell to bash"

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL := /bin/bash
-
 FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses -o -path ./vendor \) -prune -o -type f
 XARGS = xargs -0 -r
 


### PR DESCRIPTION
Reverts istio/common-files#275

About 99% sure this is the root cause of https://github.com/istio/istio/issues/25463. Basically we don't have pipe-file so `exit 5 | tee` ends up with a 0 exit code