### PR TITLE
Bump build-tools image tag to master-2020-07-13T16-10-49

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -59,7 +59,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=master-2020-07-10T02-22-20
+  export IMAGE_VERSION=master-2020-07-13T16-10-49
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools


### PR DESCRIPTION
To pull in changes from #1073

Tested by running this in the tools repo:
```sh
IMAGE_VERSION=master-2020-07-13T16-10-49 make lint-licenses
```