### PR TITLE
Bump Build image - Fix golangci-lint fault - Update golangci-lint, upx

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -59,7 +59,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=master-2020-07-16T17-15-45
+  export IMAGE_VERSION=master-2020-07-16T22-57-32
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools


### PR DESCRIPTION
Before the change:
```
make lint 
common/scripts/lint_go.sh: line 24:  4111 Segmentation fault      golangci-lint run -v -c ./common/config/.golangci.yml
common/Makefile.common.mk:47: recipe for target 'lint-go' failed
```
With new image:
```
IMAGE_VERSION=master-2020-07-16T22-57-32 make lint
INFO [config_reader] Used config file common/config/.golangci.yml
INFO [lintersdb] Active 19 linters: [deadcode errcheck gocritic gofmt goimports golint gosimple govet ineffassign interfacer lll misspell staticcheck structcheck stylecheck typecheck unconvert unparam varcheck]
...
```