### PR TITLE
Disable interfacer linter

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -41,7 +41,6 @@ linters:
   - gosimple
   - govet
   - ineffassign
-  - interfacer
   - lll
   - misspell
   - staticcheck


### PR DESCRIPTION
IMO this linter provides antipattern advices. It constantly provides bad advice like replacing generic interfaces `test.Failer` with some obscure interface like `gomega.Testing`. As a result, its one of the most skipped linters:

```
$ match 'nolint.*' | map '"".join(i.split(":")[1:]).strip()' | sort | uniq -c | sort -n
      1 adapterlinter") {
      1 deadcode
      1 goconst
      1 megacheck
      1 structcheck
      2 adapterlinter
      3 gocritic
      3 goimports
      3 gosimple
      3 govet
      5 structcheck, unused
     10 golint
     10 golint, stylecheck
     12 errcheck
     14 maligned
     14 vetshadow
     16 golint,stylecheck
     23 staticcheck
     29
     32 unparam
     38 interfacer
     40 gas
     95 lll
```