### PR TITLE
Use /home/.cache as a volume mount

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -50,6 +50,6 @@ export REPO_ROOT=/work
     --mount "type=bind,source=${PWD},destination=/work,consistency=cached" \
     --mount "type=volume,source=go,destination=/go,consistency=cached" \
     --mount "type=volume,source=gocache,destination=/gocache,consistency=cached" \
-    --mount "type=volume,source=cache,destination=/home/.cache,consistency=delegated" \
+    --mount "type=volume,source=cache,destination=/home/.cache,consistency=cached" \
     ${CONDITIONAL_HOST_MOUNTS} \
     -w /work "${IMG}" "$@"

--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -50,5 +50,6 @@ export REPO_ROOT=/work
     --mount "type=bind,source=${PWD},destination=/work,consistency=cached" \
     --mount "type=volume,source=go,destination=/go,consistency=cached" \
     --mount "type=volume,source=gocache,destination=/gocache,consistency=cached" \
+    --mount "type=volume,source=cache,destination=/home/.cache,consistency=delegated" \
     ${CONDITIONAL_HOST_MOUNTS} \
     -w /work "${IMG}" "$@"


### PR DESCRIPTION
The proxy build uses /home/.cache to store envoy proxy output. Use that
directory as a volume mount to store the output of the build results.
This takes a 20 minute build to 12 seconds on my gear. This does not
solve the problem that the proxy build does not output binaries,
however, it gets Istio closer to that goal.