### PR TITLE
Fix KUBECONFIG when running script directly

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -145,7 +145,7 @@ fi
 
 KUBECONFIG=${KUBECONFIG:="$HOME/.kube/config"}
 parse_KUBECONFIG "${KUBECONFIG}"
-if [[ "$BUILD_WITH_CONTAINER" -eq "1" ]]; then
+if [[ "${BUILD_WITH_CONTAINER:-1}" -eq "1" ]]; then
   export KUBECONFIG="${container_kubeconfig%?}"
 fi
 


### PR DESCRIPTION
Fixes `./common/scripts/run.sh kubectl get pods`. BUILD_WITH_CONTAINER is not defaulted in this case