### PR TITLE
Ability to ignore a dirty tree when reporting tree status

### DIFF
--- a/files/common/scripts/report_build_info.sh
+++ b/files/common/scripts/report_build_info.sh
@@ -22,7 +22,7 @@
 #   limitations under the License.
 
 if BUILD_GIT_REVISION=$(git rev-parse HEAD 2> /dev/null); then
-  if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  if [[ -z "${IGNORE_DIRTY_TREE}" ]] && [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
     BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
   fi
 else
@@ -30,9 +30,8 @@ else
 fi
 
 # Check for local changes
-if git diff-index --quiet HEAD --; then
-  tree_status="Clean"
-else
+tree_status="Clean"
+if [[ -z "${IGNORE_DIRTY_TREE}" ]] && ! git diff-index --quiet HEAD --; then
   tree_status="Modified"
 fi
 


### PR DESCRIPTION
By using the `IGNORE_DIRTY_TREE` env variable. If it is set, we ignore
dirty/modified tree status and report a clean tree to be used by
`<binary> version` subcommand.