### PR TITLE
Use the variable VERSION, if it is defined

### DIFF
--- a/files/common/scripts/report_build_info.sh
+++ b/files/common/scripts/report_build_info.sh
@@ -35,17 +35,11 @@ if [[ -z "${IGNORE_DIRTY_TREE}" ]] && ! git diff-index --quiet HEAD --; then
   tree_status="Modified"
 fi
 
-# security wanted VERSION='unknown'
-VERSION="${BUILD_GIT_REVISION}"
-if [[ -n ${ISTIO_VERSION} ]]; then
-  VERSION="${ISTIO_VERSION}"
-fi
-
 GIT_DESCRIBE_TAG=$(git describe --tags)
 HUB=${HUB:-"docker.io/istio"}
 
 # used by common/scripts/gobuild.sh
-echo "istio.io/pkg/version.buildVersion=${VERSION}"
+echo "istio.io/pkg/version.buildVersion=${VERSION:-$BUILD_GIT_REVISION}"
 echo "istio.io/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
 echo "istio.io/pkg/version.buildStatus=${tree_status}"
 echo "istio.io/pkg/version.buildTag=${GIT_DESCRIBE_TAG}"


### PR DESCRIPTION
The variable ISTIO_VERSION isn't defined anywhere (actually it is in release-builder
repo, but it's not needed, I'll remove it) but VERSION is defined in Makefile.core.mk.

This allows developer builds to print something like this:
```
$ ./out/linux_amd64/istioctl version --short=false --remote=false
version.BuildInfo{Version:"1.8-dev", GitRevision:"96f07bf388573cb94d5d92a26c058ed321bc4447",...
```
Instead of duplicating the git revision.

Users are able to override this at build time with
```
$ VERSION=1.8-my-feature make build
```