### PR TITLE
Create passwd entry and group entry on startup of container

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -41,8 +41,6 @@ export REPO_ROOT=/work
     -u "${UID}:${DOCKER_GID}" \
     --sig-proxy=true \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
-    -v /etc/passwd:/etc/passwd:ro \
-    -v /etc/group:/etc/group:ro \
     $CONTAINER_OPTIONS \
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
     -e IN_BUILD_CONTAINER=1 \

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -59,7 +59,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=master-2020-09-02T23-35-59
+  export IMAGE_VERSION=master-2020-09-04T21-07-25
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools


### PR DESCRIPTION
This doesn't add much overhead, but ensures credentials are
consistent across platforms, specially MacOS and Linux.

This happens by not mounting passwd nor groups, and instead adding
these files at startup of the docker container.

Depends-On: https://github.com/istio/tools/pull/1196