### PR TITLE
fix container_kubeconfig path - should have been /config instead of /home

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -109,7 +109,7 @@ fi
 add_KUBECONFIG_if_exists () {
   if [[ -f "$1" ]]; then
     kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
-    container_kubeconfig+="/home/${kubeconfig_random}:"
+    container_kubeconfig+="/config/${kubeconfig_random}:"
     CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly "
   fi
 }


### PR DESCRIPTION
Problem - when building within container, `KUBECONFIG` has to be set right. Unfortunately, due to this issue it wasn't the case. It looked like an obvious mistake because in mount it is `/config/...`, but in `container_kubeconfig` which is set as `KUBECONFIG` it is `/home`. This is wrong. This may not cause issues for single cluster tests within container, but for multi-cluster ones it does. This makes running multicluster tests in local environment very hard.

Related PR for setting up multicluster testing environment - https://github.com/istio/istio.io/pull/8088 