### PR TITLE
KUBECONFIGS should be exported so that it can be used downstream

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -225,7 +225,7 @@ EOF
 
   # Install MetalLB for LoadBalancer support. Must be done synchronously since METALLB_IPS is shared.
   # and keep track of the list of Kubeconfig files that will be exported later
-  declare -a KUBECONFIGS
+  export KUBECONFIGS
   for CLUSTER_NAME in "${CLUSTER_NAMES[@]}"; do
     KUBECONFIG_FILE="${KUBECONFIG_DIR}/${CLUSTER_NAME}"
     if [[ ${NUM_CLUSTERS} -gt 1 ]]; then


### PR DESCRIPTION
We will use in `prow/integ-suite-kind.sh` to create a `:` separated string `KUBECONFIG` to feed it to `setup_env.sh` script so that the required kubeconfig files are mounted to the container properly.