### PR TITLE
Allow override of DOCKER_GID in setup_env.sh

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -66,7 +66,7 @@ if [[ "${IMAGE_NAME:-}" == "" ]]; then
 fi
 
 export UID
-DOCKER_GID=$(grep '^docker:' /etc/group | cut -f3 -d:)
+DOCKER_GID="${DOCKER_GID:-$(grep '^docker:' /etc/group | cut -f3 -d:)}"
 export DOCKER_GID
 
 TIMEZONE=$(readlink "$readlink_flags" /etc/localtime | sed -e 's/^.*zoneinfo\///')


### PR DESCRIPTION
I connect to a remote Docker instance and don't have the group present locally. I'd like to be able to set the group ID manually.