### PR TITLE
Disable empty-values

### DIFF
--- a/files/common/config/.yamllint.yml
+++ b/files/common/config/.yamllint.yml
@@ -15,7 +15,7 @@ rules:
   document-end: disable
   document-start: disable
   empty-lines: disable
-  empty-values: enable
+  empty-values: disable
   hyphens: enable
   indentation: disable
   key-duplicates: enable


### PR DESCRIPTION
A new version of yamllint we upgraded to means this is breaking on 100s of yaml files. I don't think its feasible or desirable to fix all of these