### PR TITLE
Disable yamllint octal-values

### DIFF
--- a/files/common/config/.yamllint.yml
+++ b/files/common/config/.yamllint.yml
@@ -23,7 +23,7 @@ rules:
   line-length: disable
   new-line-at-end-of-file: disable
   new-lines: enable
-  octal-values: enable
+  octal-values: disable
   quoted-strings: disable
   trailing-spaces: disable
   truthy: disable


### PR DESCRIPTION
Trying to satisfy the linter in `test-infra` by enclosing the value in single quotes leads to an error:
```
Could not load config: error unmarshaling ../cluster/jobs/all-presets.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field KeyToPath.presets.volumes.secret.items.mode of type int32
```

Thus disabling the particular linter that was picking up new linting errors like:
```
./prow/cluster/jobs/all-presets.yaml
  135:19    error    forbidden implicit octal value "0600"  (octal-values)
  150:19    error    forbidden implicit octal value "0600"  (octal-values)
  165:19    error    forbidden implicit octal value "0600"  (octal-values)
  180:19    error    forbidden implicit octal value "0600"  (octal-values)
```