### PR TITLE
Update lint-yaml to not fail when no files containing {{ are found

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -29,7 +29,7 @@ lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
 
 lint-yaml:
-	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" | xargs -r yamllint -c ./common/config/.yamllint.yml
+	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -not -exec grep -q -e "{{" {} \; -print0 | ${XARGS} yamllint -c ./common/config/.yamllint.yml
 
 lint-helm:
 	@${FINDFILES} -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict


### PR DESCRIPTION
The turning off of `pipefail` was recently removed from the lint-yaml target's command. 

This caused lint-yaml to fail in the istio.io repo, and a workaround was applied there turning off `pipefail`.

The reason for the failure is the `grep -L -e "{{"` in the istio.io repo doesn't find any files containing {{ to remove (the -L option) and thus `grep` returns a 1. With the default `pipefail` used in Istio, this caused the whole command to fail.

The lint-yaml target's command was rewritten to not use the` grep` return code in the pipeline directly and have `find` use `grep` to determine if the files should be passed to yamllint.

I tested this change in an istio.io PR https://github.com/istio/istio.io/pull/8257 as well as making the change locally in istio/istio to verify things work.