### PR TITLE
automatically detect whether to run `docker run -it` or just `docker run`

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -37,11 +37,18 @@ export REPO_ROOT=/work
 MOUNT_SOURCE="${MOUNT_SOURCE:-${PWD}}"
 MOUNT_DEST="${MOUNT_DEST:-/work}"
 
+read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
+
+[[ -t 1 ]] && DOCKER_RUN_OPTIONS+=("-it")
+
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
 # shellcheck disable=SC2086
-"${CONTAINER_CLI}" run --init -it --rm \
+"${CONTAINER_CLI}" run \
+    --rm \
+    "${DOCKER_RUN_OPTIONS[@]}" \
     -u "${UID}:${DOCKER_GID}" \
+    --init \
     --sig-proxy=true \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
     $CONTAINER_OPTIONS \


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

## Summary

* to be able to run Docker-based commands on GitHub Actions, automatically detect when it's possible to run `docker run -it` and when it should be just `docker run` 