### PR TITLE
Bump build-tools

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -59,7 +59,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=release-1.7-2020-11-24T18-25-03
+  export IMAGE_VERSION=release-1.7-2020-11-25T22-57-38
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -59,7 +59,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=release-1.7-2020-11-13T11-06-08
+  export IMAGE_VERSION=release-1.7-2020-11-24T18-25-03
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools


### PR DESCRIPTION
Pulls in changes to fix lint missing helm, and kubetest2

tag is found here: gcr.io/istio-testing/build-tools

https://github.com/istio/tools/pull/1342
https://github.com/istio/tools/pull/1345
