### PR TITLE
Make KUBECONFIG_DIR deterministic

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -189,7 +189,7 @@ function cleanup_kind_clusters() {
 # cluster topology information to be loaded in advance
 function setup_kind_clusters() {
   IMAGE="${1:-"${DEFAULT_KIND_IMAGE}"}"
-  KUBECONFIG_DIR="$(mktemp -d)"
+  KUBECONFIG_DIR="${ARTIFACTS:-$(mktemp -d)}/kubeconfig"
   IP_FAMILY="${2:-ipv4}"
 
   check_default_cluster_yaml


### PR DESCRIPTION
This supports local runs, by not needing to dig through the logs to find the dir. Also will show up in prow output which could be useful

Part of https://github.com/istio/istio/issues/29610