### PR TITLE
Remove [] on CLUSTER_NETWORK_ID

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -78,7 +78,7 @@ function load_cluster_topology() {
 
   while read -r value; do
     CLUSTER_NETWORK_ID+=("$value")
-  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.[].network_id // .network')
+  done < <(echo "${KUBE_CLUSTERS}" | jq -r '.network_id // .network')
 
   export NUM_CLUSTERS
   NUM_CLUSTERS=$(jq 'length' "${CLUSTER_TOPOLOGY_CONFIG_FILE}")


### PR DESCRIPTION
Fix /home/prow/go/src/istio.io/istio.io/common/scripts/kind_provisioner.sh: line 260: CLUSTER_NETWORK_ID[i]: unbound variable showing up in multicluster tests.

Changes where made to several lines in #372 but this line didn't have the .[] removed.