### PR TITLE
Negate Golang 1.16 go mod download affecting go.sum

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -73,6 +73,12 @@ tidy-go:
 
 mod-download-go:
 	@-GOFLAGS="-mod=readonly" go mod download
+# go mod tidy is needed with Golang 1.16+ as go mod download affects go.sum
+# https://github.com/golang/go/issues/43994
+	@go mod tidy
+
+list-all-go:
+	@-GOFLAGS="-mod=readonly" go list -deps -test
 
 format-go: tidy-go
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/format_go.sh


### PR DESCRIPTION
Golang 1.16 RC 1 has a behavior change where `go mod download` affects the go.sum file adding additional listed modules. These additional modules in go.sum are removed with a `go mod tidy`. @howardjohn wrote https://github.com/golang/go/issues/43994 for the change in behavior which was closed as working as designed.

Two Istio PRs were already merged to change the order of targets so that the `go mod tidy` happened after the `go mod download` during a `make gen` so the go.sum file doesn't highlight a change. This PR is adding a `go mod tidy` within the makefile target containing the `go mod download` so the target itself won't have an overall effect on go.sum.

Some testing shows that `go mod download` places about 1.55 GB of modules into the cache. In John's PR they mentioned using `go list` instead of `go mod download` as the number of modules downloaded will be less and go.sum will not be affected. `go list` downloads about 750 MB worth of files.

The `go mod download` was added into the makefiles when the license-lint related targets were added. It was a precursor to the license-lint call. The license-lint code actually does a `go list -mod=readonly -deps -test ./...` so doing the `go mod download` is not actually needed.

I did add an extra target which downloads the files using `go list`, just to highlight an alternative command/target. It is possible to remove the lines between the mod-download-go and list-all-go targets so both just do the `go list`.

@jwendell, I know you made some changes in this space, so would like your feedback as well.