### PR TITLE
Remove extraneous target

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -77,9 +77,6 @@ mod-download-go:
 # https://github.com/golang/go/issues/43994
 	@go mod tidy
 
-list-all-go:
-	@-GOFLAGS="-mod=readonly" go list -deps -test
-
 format-go: tidy-go
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/format_go.sh
 


### PR DESCRIPTION
Remove the extraneous target added in #382.  Hopefully with https://github.com/istio/test-infra/pull/3168, the automation will push this change to the repos unblocking the AUTOMATOR PRs that are failing the gen checks.