### PR TITLE
Add exception for go-errors/errors

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -101,3 +101,6 @@ allowlisted_modules:
 
 # MIT: https://github.com/kubernetes-sigs/yaml/blob/master/LICENSE
 - sigs.k8s.io/yaml
+
+# https://github.com/go-errors/errors/blob/master/LICENSE.MIT
+- github.com/go-errors/errors


### PR DESCRIPTION
Not sure why it fails, but its clearly MIT. The dependency comes from Kubernetes.