### PR TITLE
files/Makefile: fix shell target to be phony

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -51,7 +51,7 @@ default:
 shell:
 	@$(RUN) /bin/bash
 
-.PHONY: default
+.PHONY: default shell
 
 else
 


### PR DESCRIPTION
This commit fixes an issue with istio proxy repository if a file with a
name "shell" exists:

$ BUILD_WITH_CONTAINER=1 make shell
make: 'shell' is up to date.