### PR TITLE
add exportloopref linter

### DIFF
--- a/files/common/config/.golangci-format.yml
+++ b/files/common/config/.golangci-format.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.27.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.38.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m

--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.27.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.38.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m
@@ -37,6 +37,7 @@ linters:
   enable:
   - deadcode
   - errcheck
+  - exportloopref
   - gocritic
   - gofumpt
   - goimports


### PR DESCRIPTION
This PR follows after istio/istio#32960 to enable linter detection.

It also updates the versions listed in the local config files to match the versioned linked in tools repo (https://github.com/istio/tools/blob/master/docker/build-tools/Dockerfile#L45).