### PR TITLE
files/Makefile: allow custom command with shell target

### DIFF
--- a/files/Makefile
+++ b/files/Makefile
@@ -39,6 +39,7 @@ export
 $(shell $(shell pwd)/common/scripts/setup_env.sh)
 
 RUN = ./common/scripts/run.sh
+CMD ?= /bin/bash
 
 MAKE_DOCKER = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 
@@ -49,7 +50,7 @@ default:
 	@$(MAKE_DOCKER)
 
 shell:
-	@$(RUN) /bin/bash
+	@$(RUN) $(CMD)
 
 .PHONY: default shell
 


### PR DESCRIPTION
This commit adds feature to Makefile to run other commands besides
/bin/bash in build-tools container. By default /bin/bash will run, but
that can be overridden with CMD variable.

Running custom commands besides bash is useful for automation of tasks
in scripts. For example, this command would return output path of bazel

BUILD_WITH_CONTAINER=1 make shell CMD='bazel info output_path'