### PR TITLE
Remove unsupported golangci-lint setting for gofumpt simplify

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -72,9 +72,6 @@ linters-settings:
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0
-  gofumpt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes


### PR DESCRIPTION
The setting to simplify code is not supported by `golangci-lint` according to
https://github.com/golangci/golangci-lint/blob/505ed3c0f7fc4941a76e52c00e462ad38ecb79ec/.golangci.example.yml#L261.

This was for `gofmt` previously.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>