### PR TITLE
Allowlist github.com/google/pprof to update k8s.io/test-infra dependency for istio.io/test-infra repo

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -111,3 +111,6 @@ allowlisted_modules:
 
 # MIT: https://github.com/felixge/fgprof/blob/master/LICENSE.txt
 - github.com/felixge/fgprof
+
+# Apache 2.0
+- github.com/google/pprof


### PR DESCRIPTION
To fix the presubmit test failure for https://github.com/istio/test-infra/pull/3452