### PR TITLE
Update build-tools: update golang, shellcheck, containerd, docs tooling

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -65,7 +65,7 @@ fi
 
 # Build image to use
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  export IMAGE_VERSION=master-2021-09-08T17-55-51
+  export IMAGE_VERSION=master-2021-09-10T19-16-17
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   export IMAGE_NAME=build-tools


### PR DESCRIPTION
Manual creation of the PR as the automation is now building the image, appears to update the Gile correctly, but failing to create the PR (see bottom of https://storage.googleapis.com/istio-prow/logs/containers_tools_postsubmit/1436408112142618624/build-log.txt):
```
master-latest: digest: sha256:ed7cdd75dfae2e4e6131eda25f18e7fb6e1805e20063ca5b262730c1fa9ecf25 size: 2215
++ grep '+ VERSION' make.out
++ sed -e 's/.*=//'
+ IMAGE_VERSION=master-2021-09-10T19-16-17
+ popd
/tmp/ci-lI81gpho8y/src/istio.io/common-files
+ /home/prow/go/src/istio.io/common-files/bin/update-build-image.sh --image master-2021-09-10T19-16-17
Updating IMAGE_VERSION to master-2021-09-10T19-16-17
/tmp/ci-lI81gpho8y ~/prow/go/src/istio.io/tools
~/prow/go/src/istio.io/tools
+ cleanup
+ log 'Starting cleanup...'
```