### PR TITLE
Use AUTOMATOR_REPO_DIR if set to call script (implies running pipeline)

### DIFF
--- a/bin/create-buildtools-and-update.sh
+++ b/bin/create-buildtools-and-update.sh
@@ -18,7 +18,7 @@ set -euxo pipefail
 # This script needs two istio repositories, tools and common-files, expecting
 # both will be cloned into a common parent directory. This script will
 # traverse to the tools repository to build new build-tools images and then
-# return, finally running the script to update the IMAGE_VERSION.
+# return.
 ROOT="$(cd -P "$(dirname -- "$0")" && pwd -P)"
 
 # pushd to the tools repo and build the images. Use tee so we can see
@@ -28,5 +28,12 @@ make containers 2>&1 | tee make.out
 IMAGE_VERSION=$(grep "+ VERSION" make.out | sed -e 's/.*=//')
 popd
 
-# Update the common files with the image version
+# Update the common files with the image version. As noted above, the expectation is
+# that common-files and tools are both in a parent directory. In the case of the build
+# pipeline this is true (both are under ~/prow/go/srd/istio.io). However, the pipeline
+# has cloned a copy of the common-files repository to /tmp/./src/istio.io/common-files
+# to watch for changes.
+# In the case of the pipeline, we want to run the bin/update_build_image.sh from the
+# automator cloned directory ($AUTOMATOR_REPO_DIR).
+if [ -n "$AUTOMATOR_REPO_DIR" ]; then ROOT=${AUTOMATOR_REPO_DIR}/bin; fi
 ${ROOT}/update-build-image.sh --image $IMAGE_VERSION


### PR DESCRIPTION
Looking at https://storage.googleapis.com/istio-prow/logs/containers_tools_postsubmit/1436408112142618624/build-log.txt, namely:
```
++ grep '+ VERSION' make.out
++ sed -e 's/.*=//'
+ IMAGE_VERSION=master-2021-09-10T19-16-17
+ popd
/tmp/ci-lI81gpho8y/src/istio.io/common-files
+ /home/prow/go/src/istio.io/common-files/bin/update-build-image.sh --image master-2021-09-10T19-16-17
Updating IMAGE_VERSION to master-2021-09-10T19-16-17
/tmp/ci-lI81gpho8y ~/prow/go/src/istio.io/tools
~/prow/go/src/istio.io/tools
```

What happens is the automation needs two repos to start, test-infra for the automator script and common-files for the create-buildtools-and-update script. The reason we need common-files is that the automator script verifies the passed in script exists when it initializes. However, the automator script is watching for changes in the repo it clones. As seen above, the script is updated the image in the original common-files directory and not the one the automator script is watching.

This change makes sure that if we are using the automator script, we use it's environment variable to find the location to run the IMAGE_VERSION update.