### PR TITLE
Remove go version check

### DIFF
--- a/files/common/scripts/gobuild.sh
+++ b/files/common/scripts/gobuild.sh
@@ -70,14 +70,6 @@ while read -r line; do
     LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
 
-# verify go version before build
-# NB. this was copied verbatim from Kubernetes hack
-minimum_go_version=go1.13 # supported patterns: go1.x, go1.x.x (x should be a number)
-IFS=" " read -ra go_version <<< "$(${GOBINARY} version)"
-if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
-    echo "Warning: Detected that you are using an older version of the Go compiler. Istio requires ${minimum_go_version} or greater."
-fi
-
 OPTIMIZATION_FLAGS=(-trimpath)
 if [ "${DEBUG}" == "1" ]; then
     OPTIMIZATION_FLAGS=()


### PR DESCRIPTION
Clearly not used anymore since we have been past go 1.13 for a while.
Go has this first class now.