### PR TITLE
Update for hadolint - Ignore Multiple consecutive RUN instructions.

### DIFF
--- a/files/common/config/.hadolint.yml
+++ b/files/common/config/.hadolint.yml
@@ -7,6 +7,7 @@
 
 ignored:
   - DL3008
+  - DL3059
 
 trustedRegistries:
   - gcr.io


### PR DESCRIPTION
Message is an Info message:

DL3059 | Info | Multiple consecutive RUN instructions. Consider consolidation.

This message shows up when running with the latest hadolint. Add to the ignore file in preparation for updating the linter.


