### PR TITLE
Remove strict on helm linter (so it won't fail on deprecation warnings)

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -32,7 +32,7 @@ lint-yaml:
 	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -not -exec grep -q -e "{{" {} \; -print0 | ${XARGS} yamllint -c ./common/config/.yamllint.yml
 
 lint-helm:
-	@${FINDFILES} -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict
+	@${FINDFILES} -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint
 
 lint-copyright-banner:
 	@${FINDFILES} \( -name '*.go' -o -name '*.cc' -o -name '*.h' -o -name '*.proto' -o -name '*.py' -o -name '*.sh' \) \( ! \( -name '*.gen.go' -o -name '*.pb.go' -o -name '*_pb2.py' \) \) -print0 |\


### PR DESCRIPTION
Similar to https://github.com/istio/istio/pull/36996, there is another lint failure in a post-submit: https://prow.istio.io/view/gs/istio-prow/logs/lint_tools_postsubmit/1486403734660452352.

This is because of a change in the Helm linter as we upgraded versions.

This makes a similar change to the overall helm linting for the project. I'm not sure if this makes sense for the whole Istio project.

I do not see a way to not error on a subset of warnings.