### PR TITLE
Do not blocklist `GO` env vars

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -93,7 +93,7 @@ IMG="${IMG:-gcr.io/istio-testing/${IMAGE_NAME}:${IMAGE_VERSION}}"
 
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 
-ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|PATH\|SHELL\|EDITOR\|TMUX\|USER\|HOME\|PWD\|TERM\|GO\|rvm\|SSH\|TMPDIR\|CC\|CXX\|MAKEFILE_LIST}"
+ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|PATH\|SHELL\|EDITOR\|TMUX\|USER\|HOME\|PWD\|TERM\|rvm\|SSH\|TMPDIR\|CC\|CXX\|MAKEFILE_LIST}"
 
 # Remove functions from the list of exported variables, they mess up with the `env` command.
 for f in $(declare -F -x | cut -d ' ' -f 3);


### PR DESCRIPTION
I have had this be an issue 3 times recently - trying to set GOBUILDFLAGS, CGO_ENABLED, and GOPRIVATE.

I don't see any compelling reason to not allow these variables. The ones that users cannot set, like GOPATH, are things we overwrite anyways