### PR TITLE
Remove override of REPO_ROOT in build container

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -185,7 +185,6 @@ if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
   # Override variables with container specific
   TARGET_OUT=${CONTAINER_TARGET_OUT}
   TARGET_OUT_LINUX=${CONTAINER_TARGET_OUT_LINUX}
-  REPO_ROOT=/work
 fi
 
 go_os_arch=${LOCAL_OUT##*/}


### PR DESCRIPTION
This is the first part of fixing https://github.com/istio/istio/issues/38103.  `docker-builder` looks at REPO_ROOT to get the location to copy files. When used with a local release-builder build, this causes the docker files to be read from the release-builder repo where they do not exist.