### PR TITLE
Revert "Remove override of REPO_ROOT in build container"

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -185,6 +185,7 @@ if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
   # Override variables with container specific
   TARGET_OUT=${CONTAINER_TARGET_OUT}
   TARGET_OUT_LINUX=${CONTAINER_TARGET_OUT_LINUX}
+  REPO_ROOT=/work
 fi
 
 go_os_arch=${LOCAL_OUT##*/}


### PR DESCRIPTION
Reverts istio/common-files#564

`make gen` is failing in istio/istio which is a higher priority than release-builder at the moment. Revert this so istio/istio is working and will see if there is a better way to attack release-builder.