### PR TITLE
Make ENV_BLOCKLIST more accurate

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -93,7 +93,7 @@ IMG="${IMG:-gcr.io/istio-testing/${IMAGE_NAME}:${IMAGE_VERSION}}"
 
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 
-ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|PATH\|SHELL\|EDITOR\|TMUX\|USER\|HOME\|PWD\|TERM\|rvm\|SSH\|TMPDIR\|CC\|CXX\|MAKEFILE_LIST}"
+ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|^PATH=\|^SHELL=\|^EDITOR=\|^TMUX=\|^USER=\|^HOME=\|^PWD=\|^TERM=\|^rvm=\|^SSH=\|^TMPDIR=\|^CC=\|^CXX=\|^MAKEFILE_LIST=}"
 
 # Remove functions from the list of exported variables, they mess up with the `env` command.
 for f in $(declare -F -x | cut -d ' ' -f 3);


### PR DESCRIPTION
Currently it will block any variable *containing* any of the strings.

This blocks, for instance, the variable `ISTIO_ENVOY_LINUX_RELEASE_PATH`
to be exported to the container, because it contains the word `PATH` in
it.