### PR TITLE
Remove trap to prevent early cluster termination

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -205,23 +205,27 @@ EOF
   # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
   # otherwise pods stops trying to resolve the domain.
   if [ "${IP_FAMILY}" = "ipv6" ] || [ "${IP_FAMILY}" = "dual" ]; then
-      # Get the current config
-      original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
-      echo "Original CoreDNS config:"
-      echo "${original_coredns}"
-      # Patch it
-      fixed_coredns=$(
-        printf '%s' "${original_coredns}" | sed \
-          -e 's/^.*kubernetes cluster\.local/& internal/' \
-          -e '/^.*upstream$/d' \
-          -e '/^.*fallthrough.*$/d' \
-          -e '/^.*forward . \/etc\/resolv.conf$/d' \
-          -e '/^.*loop$/d' \
-      )
-      echo "Patched CoreDNS config:"
-      echo "${fixed_coredns}"
-      printf '%s' "${fixed_coredns}" | kubectl apply -f -
-    fi
+    # Get the current config
+    original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+    echo "Original CoreDNS config:"
+    echo "${original_coredns}"
+    # Patch it
+    fixed_coredns=$(
+      printf '%s' "${original_coredns}" | sed \
+        -e 's/^.*kubernetes cluster\.local/& internal/' \
+        -e '/^.*upstream$/d' \
+        -e '/^.*fallthrough.*$/d' \
+        -e '/^.*forward . \/etc\/resolv.conf$/d' \
+        -e '/^.*loop$/d' \
+    )
+    echo "Patched CoreDNS config:"
+    echo "${fixed_coredns}"
+    printf '%s' "${fixed_coredns}" | kubectl apply -f -
+  fi
+
+  # On Ubuntu Jammy, the trap runs when this function exits. Remove trap to prevent
+  # cluster shutdown here.
+  trap EXIT
 }
 
 ###############################################################################
@@ -252,7 +256,7 @@ function setup_kind_clusters() {
 
   check_default_cluster_yaml
 
-  # Trap replaces any previous trap's, so we need to explicitly cleanup both clusters here
+  # Trap replaces any previous trap's, so we need to explicitly cleanup clusters here
   trap cleanup_kind_clusters EXIT
 
   function deploy_kind() {


### PR DESCRIPTION
Investigating why we see tests fail when updating to a Jammy based build image. Looking at the logs (ex. https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/38505/integ-pilot-istiodremote_istio/1517625011815321600/build-log.txt) , I see that the kind clusters get created, and then promptly deleted, so when the MetalLB is being installed, the are errors accessing the cluster:
```
+ docker exec config-control-plane bash -c 'sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited'
 ✓ Waiting ≤ 3m0s for control-plane = Ready ⏳
 • Ready after 24s 💚
kernel.core_pattern = /var/lib/istio/data/core.proxy
+ break
++ cleanup_kind_cluster config
++ echo 'Test exited with exit code 0.'
Test exited with exit code 0.
....
++ echo 'Cleaning up kind cluster'
Cleaning up kind cluster
++ kind delete cluster --name config -v9
...
+ kubectl apply --kubeconfig=/logs/artifacts/kubeconfig/config -f /home/prow/go/src/istio.io/istio/common/scripts/metallb.yaml
Unable to connect to the server: dial tcp 172.18.0.2:6443: connect: no route to host
```
Looking at logs before Jammy, the cleaning up of the kind cluster only happens at the end of the job.

looking at the source, it appears that Jammy is running the trap as the `setup_kind_cluster` function exits, deleting the cluster just after it is created. This change removes the exit before exiting the function so the cluster is not deleted.

I'm not sure if this is a fix in behavior (traps now work on function exit) or if this is a bug in the Jammy implementation.