### PR TITLE
Fix `make gen` in istio.io and release-builder

### DIFF
--- a/files/common/config/.golangci-format.yml
+++ b/files/common/config/.golangci-format.yml
@@ -44,6 +44,11 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: istio.io/
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(istio.io/)
 
 issues:
 


### PR DESCRIPTION
I am seeing some errors trying to do `make gen` in a few repos:
```
pkg/util/command.go:22:3: Expected 'i', Found 's' at pkg/util/command.go[line 22,col 3] (gci)
	"sigs.k8s.io/yaml"
	 ^
pkg/util/files.go:34:1: Expected '\t', Found '\n' at pkg/util/files.go[line 34,col 1] (gci)

^
pkg/util/git.go:31:1: Expected '\t', Found '\n' at pkg/util/git.go[line 31,col 1] (gci)

^
pkg/manifest.go:23:3: Expected 'i', Found 's' at pkg/manifest.go[line 23,col 3] (gci)
	"sigs.k8s.io/yaml"
	 ^
pkg/branch/branch.go:23:3: Expected 'i', Found 's' at pkg/branch/branch.go[line 23,col 3] (gci)
	"sigs.k8s.io/yaml"
	 ^
pkg/branch/cmd.go:21:1: Expected '\t', Found '\n' at pkg/branch/cmd.go[line 21,col 1] (gci)

^
pkg/build/build.go:24:3: Expected 'i', Found 's' at pkg/build/build.go[line 24,col 3] (gci)
	"sigs.k8s.io/yaml"
	 ^
pkg/build/cmd.go:21:1: Expected '\t', Found '\n' at pkg/build/cmd.go[line 21,col 1] (gci)

^
...
```
Updating the gci setting to prevent these errors.