### PR TITLE
Remove format-protos

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -80,9 +80,6 @@ format-go: tidy-go
 format-python:
 	@${FINDFILES} -name '*.py' -print0 | ${XARGS} autopep8 --max-line-length 160 --aggressive --aggressive -i
 
-format-protos:
-	@$(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool format -w
-
 dump-licenses: mod-download-go
 	@license-lint --config common/config/license-lint.yml --report
 


### PR DESCRIPTION
This doesn't actually work, is not used anywhere, and if we did want to format protos we should use `buf`.