### PR TITLE
Fix LOCAL_OUT value inside container to be path inside the container

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -176,16 +176,13 @@ fi
 # This is used when we need to run a build artifact during tests or later as part of another
 # target.
 if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
-  LOCAL_OUT="${TARGET_OUT_LINUX}"
-else
-  LOCAL_OUT="${TARGET_OUT}"
-fi
-
-if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
   # Override variables with container specific
   TARGET_OUT=${CONTAINER_TARGET_OUT}
   TARGET_OUT_LINUX=${CONTAINER_TARGET_OUT_LINUX}
   REPO_ROOT=/work
+  LOCAL_OUT="${TARGET_OUT_LINUX}"
+else
+  LOCAL_OUT="${TARGET_OUT}"
 fi
 
 go_os_arch=${LOCAL_OUT##*/}


### PR DESCRIPTION
Looking to fix https://github.com/istio/istio/issues/39828

Currently, LOCAL_OUT points to a location on the host:
```
make shell
build-tools:/work$ env | grep OUT
LOCAL_OUT=/Users/ericvn/work/go/src/istio.io/istio/out/linux_amd64
```
Envoy and agent integration tests use LOCAL_OUT to try and find binaries and this causes them to fail if run inside a container:
```
warn	unable to resolve LOCAL_OUT. Dir /var/jenkins/workspace/istio-pre-cr/out/linux_amd64 does not exist
```

This change updates LOCAL_OUT to point to the TARGET_OUT_LINUX value as that is the location in the container with the same host mapping, but we want to also specify LINUX as the container is running LINUX (LOCAL points to architecture where we are running).
```
make shell 
build-tools:/work$ env | grep OUT
LOCAL_OUT=/work/out/linux_amd64
```

I did testing in istio/istio with this change as this is the same as the first commit in https://github.com/istio/istio/pull/40413.

The originator of the original issue also tested this change and it resolved the two issues he was seeing.