### PR TITLE
Updates noted while converting istio/community to use common-files

### DIFF
--- a/files/LICENSE
+++ b/files/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2020 Istio Authors
+   Copyright 2016-2022 Istio Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -99,9 +99,10 @@ update-common:
 	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
 	@CONTRIB_OVERRIDE=$(shell grep -l "istio/community/blob/master/CONTRIBUTING.md" CONTRIBUTING.md)
-	if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
+	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
 	fi
+	@cp -a $(TMP)/common-files/files/* $(shell pwd)
 	@rm -fr $(TMP)/common-files
 
 check-clean-repo:

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -98,7 +98,10 @@ update-common:
 	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/istio/common-files $(TMP)/common-files
 	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
-	@cp -a $(TMP)/common-files/files/* $(shell pwd)
+	@CONTRIB_OVERRIDE=$(shell grep -l "istio/community/blob/master/CONTRIBUTING.md" CONTRIBUTING.md)
+	if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
+		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
+	fi
 	@rm -fr $(TMP)/common-files
 
 check-clean-repo:


### PR DESCRIPTION
Updating the istio/community repo to use common-files in https://github.com/istio/community/pull/799.

There are two comments in that PR:
 - One related to the date in the LICENSE file.
 - The other relates to the CONTRIBUTING.md file in the repos. As this common-files version of CONTRIBUTING.md simply points to the istio/community, we need to update the `update=-common` target to only update CONTRIBUTING if we are replacing a version that points to the community file. In the case of istio/community, we don't want to update the file.

For the later task, I could not determine a way to figure out which repo are are updating, so electing to only update the CONTRIBUTING.md if it contains a pointer to the istio/community file.