### PR TITLE
Fix os and arch not reported

### DIFF
--- a/files/common/scripts/gobuild.sh
+++ b/files/common/scripts/gobuild.sh
@@ -37,8 +37,8 @@ shift
 
 set -e
 
-BUILD_GOOS=${GOOS:-linux}
-BUILD_GOARCH=${GOARCH:-amd64}
+export BUILD_GOOS=${GOOS:-linux}
+export BUILD_GOARCH=${GOARCH:-amd64}
 GOBINARY=${GOBINARY:-go}
 GOPKG="$GOPATH/pkg"
 BUILDINFO=${BUILDINFO:-""}


### PR DESCRIPTION
Tried on master branch after https://github.com/istio/common-files/pull/687 get merged with `make istioctl-install`. The variables are not passed to `report_build_info.sh`, which leads to empty strings.