### PR TITLE
fix: excludes Ruby env vars

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -93,7 +93,7 @@ IMG="${IMG:-gcr.io/istio-testing/${IMAGE_NAME}:${IMAGE_VERSION}}"
 
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 
-ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|^PATH=\|^GOPATH=\|^GOROOT=\|^SHELL=\|^EDITOR=\|^TMUX=\|^USER=\|^HOME=\|^PWD=\|^TERM=\|^rvm=\|^SSH=\|^TMPDIR=\|^CC=\|^CXX=\|^MAKEFILE_LIST=}"
+ENV_BLOCKLIST="${ENV_BLOCKLIST:-^_\|^PATH=\|^GOPATH=\|^GOROOT=\|^SHELL=\|^EDITOR=\|^TMUX=\|^USER=\|^HOME=\|^PWD=\|^TERM=\|^RUBY_\|^GEM_\|^rvm_\|^SSH=\|^TMPDIR=\|^CC=\|^CXX=\|^MAKEFILE_LIST=}"
 
 # Remove functions from the list of exported variables, they mess up with the `env` command.
 for f in $(declare -F -x | cut -d ' ' -f 3);


### PR DESCRIPTION
When using tools such as `rvm` host env variables contain e.g. `GEM_HOME` and `GEM_PATH`. These might differ with what is expected by the container. 

As a consequence running tests lead to errors such as

```
build-tools:/work$ fpm
/usr/lib/ruby/vendor_ruby/rubygems.rb:265:in `find_spec_for_exe': can't find gem fpm (>= 0.a) with executable fpm (Gem::GemNotFoundException)
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:284:in `activate_bin_path'
	from /usr/local/bin/fpm:25:in `<main>'
```

This PR excludes `rvm`-related variables.