### PR TITLE
Update default k8s version to a supported version

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -32,7 +32,7 @@ set -x
 ####################################################################
 
 # DEFAULT_KIND_IMAGE is used to set the Kubernetes version for KinD unless overridden in params to setup_kind_cluster(s)
-DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.21.1"
+DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.25.4"
 
 # COMMON_SCRIPTS contains the directory this file is in.
 COMMON_SCRIPTS=$(dirname "${BASH_SOURCE:-$0}")


### PR DESCRIPTION
I believe we have overrides everywhere so this won't change much. Also, if anything does fail, it'll point to something that wouldn't work on a 1.25 version of Kubernetes.