### PR TITLE
chore: fix run as root issue

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -40,6 +40,7 @@ MOUNT_DEST="${MOUNT_DEST:-/work}"
 read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 
 [[ -t 1 ]] && DOCKER_RUN_OPTIONS+=("-it")
+[[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=("-u ${UID}:${DOCKER_GID}")
 
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
@@ -47,7 +48,6 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 "${CONTAINER_CLI}" run \
     --rm \
     "${DOCKER_RUN_OPTIONS[@]}" \
-    -u "${UID}:${DOCKER_GID}" \
     --init \
     --sig-proxy=true \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \

--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -40,7 +40,7 @@ MOUNT_DEST="${MOUNT_DEST:-/work}"
 read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 
 [[ -t 1 ]] && DOCKER_RUN_OPTIONS+=("-it")
-[[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=("-u ${UID}:${DOCKER_GID}")
+[[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=(-u "${UID}:${DOCKER_GID}")
 
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only


### PR DESCRIPTION
`make shell` returns error:

```
root:[ztunnel]$ make shell
useradd: UID 0 is not unique
groups: cannot find name for group ID 998 <===
build-tools:/work# id
uid=0(root) gid=998 groups=998
```

If run as root, no need to map uid&gid, and docker group does not exist.


Signed-off-by: Loong <loong.dai@intel.com>