### PR TITLE
Fix lint-scripts sometimes not checking files

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -26,7 +26,7 @@ lint-dockerfiles:
 	@${FINDFILES} -name 'Dockerfile*' -print0 | ${XARGS} hadolint -c ./common/config/.hadolint.yml
 
 lint-scripts:
-	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
+	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} -n 256 shellcheck
 
 lint-yaml:
 	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -not -exec grep -q -e "{{" {} \; -print0 | ${XARGS} yamllint -c ./common/config/.yamllint.yml


### PR DESCRIPTION
Occasionally the istio.io `make lint` tests will fail on a file which has not changed in the PR. It has happened twice in the last month. When this happens, it typically fails in the pipeline, but not locally.

Investigation into this,I can see that there a over 3200 script files being fed to spellcheck:
```
> find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses -o -path ./vendor \) -prune -o -type f -name "*.sh" | wc -l
    3201
```
I think we could fix this in one of two ways. One would be to limit the number of files found, as many are duplicates. For example, this single file is copied to several locations:
```
> find . -name canary_upgrade_test.sh
./content/en/docs/setup/upgrade/canary/canary_upgrade_test.sh
./public/docs/setup/upgrade/canary/canary_upgrade_test.sh
./public/zh/docs/setup/upgrade/canary/canary_upgrade_test.sh
```
Many older test have older script versions in the `./archive` directory.  
If we update the find command in the files/common/Makefile.common.mk to also omit the archive and public directories, the number of files dwindles to around 226. I searched for `public` and `archive directories in the other repos and thus would seem like it might be a good idea. However, I'm not sure about the other `lint-*` targets. Are the files all duplicates, or is there something different in them and they should be tested?

Since I couldn't easily determine that omitting the two directories is a good idea, I simply decided to limit the number of arguments being passed to spellcheck. When not set, I see no lint failures locally, when set to `-n 512` I see 4 failures in 1 file, when set as `-n 256` I see 8 errors in 2 files. Setting it to 32, does not increase the errors, so 256 sounds like a good value.

One could decide that we may need to do something similar in the other `lint-*.` targets if those commands can't handle all the arg values, but I haven't heard of any flakes in those tests.