### PR TITLE
Update to only cp .devcontainer and .gitattributes on a Mac and not .* (seems to pick up parent)

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -102,7 +102,7 @@ update-common:
 	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
 	fi
-	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.* $(shell pwd)
+	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.devcontainer $(shell pwd)
 	@rm -fr $(TMP)/common-files
 	@$(or $(COMMONFILES_POSTPROCESS), true)
 

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -102,7 +102,7 @@ update-common:
 	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
 	fi
-	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.devcontainer $(shell pwd)
+	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.devcontainer $(TMP)/common-files/files/.gitattributes $(shell pwd)
 	@rm -fr $(TMP)/common-files
 	@$(or $(COMMONFILES_POSTPROCESS), true)
 


### PR DESCRIPTION
I notice that running `make update-common` locally on a Mac after the last change causes my repository to get messed up due to the fact that it seems to also want to copy `..` with the `.*`. Not sure why the build-tools container would behavior differently on a Mac, but it does. 

Some testing before the prior change showed that the .devcontainer directory wasn't getting copied on a Mac. It appears the pipeline does copy it without special .<name> callouts.

So, we could revert back to not calling out the .<name> files which seems to copy the .files in the pipeline but not on a Mac locally. If we want the Mac to behave like the pipeline, it seems we need to call out the two copies. 

I'm fine with not incorporating this change, but if an Istio dev is using a Mac (and not sure what other platforms), they may run into tan issue that there local repository is messed up if the happen to run `make update-common`.