### PR TITLE
Update .golangci.yml from istio/istio

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -233,6 +233,28 @@ linters-settings:
   depguard:
     packages-with-error-message:
       - github.com/gogo/protobuf: "gogo/protobuf is deprecated, use golang/protobuf"
+        golang.org/x/net/http2/h2c: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"
+      - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
+      - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
+      - gomodules.xyz/jsonpatch/v3: "don't use v3; v2 is orders of magnitude higher performance"
+    additional-guards:
+      - list-type: denylist
+        packages-with-error-message:
+          - istio.io/istio/operator: "operator should not be imported"
+          - istio.io/istio/istioctl: "istioctl should not be imported"
+        # Specify rules by which the linter ignores certain files for consideration.
+        ignore-file-rules:
+          # Tests can do anything
+          - "**/*_test.go"
+          - "**/tests/**"
+          - "**/istio/pkg/test/**"
+          # Main code should only be used by appropriate binaries
+          - "**/operator/**"
+          - "**/istioctl/**"
+          - "**/tools/bug-report/**"
+          # This should only really import operator API, but that is hard to express without a larger refactoring
+          - "**/pkg/kube/**"
+          - "**/pkg/url/**"
   gosec:
     includes:
       - G401


### PR DESCRIPTION
istio/istio/common/.golangci.yaml has changes that haven't been moved into common-files. This takes what is is istio/istio today.