### PR TITLE
Update devcontainer when updating the tools image

### DIFF
--- a/bin/update-build-image.sh
+++ b/bin/update-build-image.sh
@@ -54,3 +54,4 @@ fi
 # Since common-files doesn't use a build image, make this sed work on both Mac and Ubuntu
 echo Updating IMAGE_VERSION to "$newBuildImage"
 sed -i.bak -e "s/IMAGE_VERSION=.*/IMAGE_VERSION=$newBuildImage/" ${ROOT}/../files/common/scripts/setup_env.sh && rm ${ROOT}/../files/common/scripts/setup_env.sh.bak
+cat <<< $(jq '.image = "${newBuildImage}"' ${ROOT}./files/.devcontainer/devcontainer.json) > ${ROOT}./files/.devcontainer/devcontainer.json


### PR DESCRIPTION
Attempt to update the .devcontainer when updating the tools image

This is used in the post-submit for istio/tools