### PR TITLE
Fix update_build_image to insert correct image

### DIFF
--- a/bin/update-build-image.sh
+++ b/bin/update-build-image.sh
@@ -54,4 +54,4 @@ fi
 # Since common-files doesn't use a build image, make this sed work on both Mac and Ubuntu
 echo Updating IMAGE_VERSION to "$newBuildImage"
 sed -i.bak -e "s/IMAGE_VERSION=.*/IMAGE_VERSION=$newBuildImage/" ${ROOT}/../files/common/scripts/setup_env.sh && rm ${ROOT}/../files/common/scripts/setup_env.sh.bak
-cat <<< $(jq '.image = "${newBuildImage}"' ${ROOT}/../files/.devcontainer/devcontainer.json) > ${ROOT}/../files/.devcontainer/devcontainer.json
+cat <<< $(jq --arg newBuildImage "$newBuildImage" '.image = $newBuildImage' ${ROOT}/../files/.devcontainer/devcontainer.json) > ${ROOT}/../files/.devcontainer/devcontainer.json

--- a/bin/update-build-image.sh
+++ b/bin/update-build-image.sh
@@ -54,4 +54,5 @@ fi
 # Since common-files doesn't use a build image, make this sed work on both Mac and Ubuntu
 echo Updating IMAGE_VERSION to "$newBuildImage"
 sed -i.bak -e "s/IMAGE_VERSION=.*/IMAGE_VERSION=$newBuildImage/" ${ROOT}/../files/common/scripts/setup_env.sh && rm ${ROOT}/../files/common/scripts/setup_env.sh.bak
-cat <<< $(jq --arg newBuildImage "$newBuildImage" '.image = $newBuildImage' ${ROOT}/../files/.devcontainer/devcontainer.json) > ${ROOT}/../files/.devcontainer/devcontainer.json
+fullBuildImage=${TOOLS_REGISTRY_PROVIDER}/${PROJECT_ID}/${TOOLS_REGISTRY_REPO}:${newBuildImage}
+cat <<< $(jq --arg fullBuildImage "$fullBuildImage" '.image = $fullBuildImage' ${ROOT}/../files/.devcontainer/devcontainer.json) > ${ROOT}/../files/.devcontainer/devcontainer.json


### PR DESCRIPTION
https://github.com/istio/common-files/pull/854/files has
```
 "image": "${newBuildImage}",
```

This update fixes this value.

`IMAGE_VERSION=master-38fcad28f896501db6d3e3f56d8d1685440122a8 ./update-build-image.sh`
yields:
```
--- a/files/.devcontainer/devcontainer.json
+++ b/files/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
   "name": "istio build-tools",
-  "image": "gcr.io/istio-testing/build-tools:master-62f8b507af660ecccb613e643daf5ea546222ac7",
+  "image": "gcr.io/istio-testing/build-tools:master-38fcad28f896501db6d3e3f56d8d1685440122a8",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",
```