### PR TITLE
Fix a typo in .golangci config

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -55,7 +55,7 @@ linters:
   fast: false
 linters-settings:
   errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.
     check-type-assertions: false
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;


### PR DESCRIPTION
This PR fixes a typo in the comment.