### PR TITLE
Update golangci-lint-version to 1.54.x

### DIFF
--- a/files/common/config/.golangci-format.yml
+++ b/files/common/config/.golangci-format.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.54.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m

--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.53.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.54.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m


### PR DESCRIPTION
We updated to gloangci-lint version 1.54.0 in https://github.com/istio/tools/pull/2626. This updates the config files to that same version. I previously changed these config files in the istio repo and ran with the new lint tooling and saw no changes in errors or formatting.

I dod not check all repos, so this could cause a needed lint change in one or more. Usually istio was a good predictor for whether changes were needed elsewhere.