### PR TITLE
Update golangci config to make tools update

### DIFF
--- a/files/common/config/.golangci-format.yml
+++ b/files/common/config/.golangci-format.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.54.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m

--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -7,7 +7,7 @@
 
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
-  golangci-lint-version: 1.54.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m


### PR DESCRIPTION
Match the version change in https://github.com/istio/tools/pull/2713.

I did run `make lint-go` with this change in istio/istio successfully.