### PR TITLE
Update the license file to be unmodified apache license

### DIFF
--- a/files/LICENSE
+++ b/files/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2022 Istio Authors
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Related to https://github.com/istio/istio/pull/47651/files

The "LICENSE" file is supposed to be our inclusion of an exact copy of https://www.apache.org/licenses/LICENSE-2.0.txt as required by section 4(a) of the Apache 2 license.