### PR TITLE
Make kubeconfig file writable

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -135,7 +135,7 @@ add_KUBECONFIG_if_exists () {
   if [[ -f "$1" ]]; then
     kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
     container_kubeconfig+="/config/${kubeconfig_random}:"
-    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly "
+    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random} "
   fi
 }
 


### PR DESCRIPTION
We are facing an error when invoking kind within the container:

```
 ...

 ✓ Installing StorageClass 💾
 ✓ Waiting ≤ 3m0s for control-plane = Ready ⏳
 • Ready after 15s 💚
ERROR: failed to create cluster: failed to write KUBECONFIG: open /config/8041fbc5: read-only file system

 ...
```