### PR TITLE
Don't update the CCA license file during make update-common

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -101,9 +101,15 @@ update-common:
 	@git clone -q --depth 1 --single-branch --branch $(UPDATE_BRANCH) https://github.com/$(BUILD_TOOLS_ORG)/common-files $(TMP)/common-files
 	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
+# istio/community has its own CONTRIBUTING.md file.
 	@CONTRIB_OVERRIDE=$(shell grep -l "istio/community/blob/master/CONTRIBUTING.md" CONTRIBUTING.md)
 	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
+	fi
+# istio/istio.io uses the  Creative Commons Attribution 4.0 license. Don't update LICENSE with the common Apache license.
+	@LICENSE_OVERRIDE=$(shell grep -l "Creative Commons Attribution 4.0 International Public License" LICENSE)
+	@if [ "$(LICENSE_OVERRIDE)" != "LICENSE" ]; then\
+		rm $(TMP)/common-files/files/LICENSE;\
 	fi
 	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.devcontainer $(TMP)/common-files/files/.gitattributes $(shell pwd)
 	@rm -fr $(TMP)/common-files


### PR DESCRIPTION
https://github.com/istio/istio.io/pull/14670 updates the LICENSE file in istio.io. The current `make update-common` updates the LICENSE file with the Apache license file in this repo. Update the target to not update a LICENSE file with the CCA license.