### PR TITLE
kind: Respect IP_FAMILY settings for non-default config as well

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -172,14 +172,15 @@ function setup_kind_cluster() {
   if [[ -z "${CONFIG}" ]]; then
     # Kubernetes 1.15+
     CONFIG=${DEFAULT_CLUSTER_YAML}
-    # Configure the cluster IP Family only for default configs
-    if [ "${IP_FAMILY}" != "ipv4" ]; then
-      grep "ipFamily: ${IP_FAMILY}" "${CONFIG}" || \
-      cat <<EOF >> "${CONFIG}"
+  fi
+
+  # Configure the cluster IP Family if explicitly set
+  if [ "${IP_FAMILY}" != "ipv4" ]; then
+    grep "ipFamily: ${IP_FAMILY}" "${CONFIG}" || \
+    cat <<EOF >> "${CONFIG}"
 networking:
   ipFamily: ${IP_FAMILY}
 EOF
-    fi
   fi
 
   KIND_WAIT_FLAG="--wait=180s"


### PR DESCRIPTION
Currently IP_FAMILY environment variable is mutually exclusive with `--kind-config` and only works with default kind config. This makes it less useful to test IPv6 or dualstack with other kind config combinations.

This change makes IP_FAMILY an independent setting that works for both default and custom kind config specified.