### PR TITLE
Add option for local caching

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -33,11 +33,19 @@ source "${WD}/setup_env.sh"
 
 MOUNT_SOURCE="${MOUNT_SOURCE:-${PWD}}"
 MOUNT_DEST="${MOUNT_DEST:-/work}"
+PERSIST_LOCAL_CACHE=${PERSIST_LOCAL_CACHE:-false}
+LOCAL_CACHE_DIRECTORY="${LOCAL_CACHE_DIRECTORY:-${HOME}/.cache}"
+CACHE_MOUNT='--mount "type=volume,source=cache,destination=/home/.cache"'
+
 
 read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 
 [[ -t 1 ]] && DOCKER_RUN_OPTIONS+=("-it")
 [[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=(-u "${UID}:${DOCKER_GID}")
+
+if [[ "$PERSIST_LOCAL_CACHE" == true ]]; then
+    CACHE_MOUNT="--mount "type=bind,source=${LOCAL_CACHE_DIRECTORY},destination=/home/.cache""
+fi
 
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
@@ -53,9 +61,9 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
     -e IN_BUILD_CONTAINER=1 \
     -e TZ="${TIMEZONE:-$TZ}" \
     --mount "type=bind,source=${MOUNT_SOURCE},destination=/work" \
+    ${CACHE_MOUNT} \
     --mount "type=volume,source=go,destination=/go" \
     --mount "type=volume,source=gocache,destination=/gocache" \
-    --mount "type=volume,source=cache,destination=/home/.cache" \
     --mount "type=volume,source=crates,destination=/home/.cargo/registry" \
     --mount "type=volume,source=git-crates,destination=/home/.cargo/git" \
     ${CONDITIONAL_HOST_MOUNTS} \


### PR DESCRIPTION
If the build container ever gets stopped/updated, the local cache is lost. This PR adds a flag to persist the local cache to the user's .cache directory to save expensive artifacts across builds (especially for bazel builds)
