### PR TITLE
golangci-lint: enable testifylint linter

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -15,26 +15,27 @@ run:
 linters:
   disable-all: true
   enable:
+    - depguard
     - errcheck
     - exportloopref
-    - depguard
     - gocritic
     - gofumpt
     - goimports
-    - revive
     - gosimple
     - govet
+    - gci
+    - gosec
     - ineffassign
     - lll
     - misspell
+    - revive
     - staticcheck
     - stylecheck
+    - testifylint
     - typecheck
     - unconvert
     - unparam
     - unused
-    - gci
-    - gosec
   fast: false
 linters-settings:
   errcheck:


### PR DESCRIPTION
golangci-lint: enable [testifylint](https://github.com/Antonboom/testifylint) linter

It will help test quality and clarity by following testify best practices