### PR TITLE
Fix chainguard allow rule

### DIFF
--- a/files/common/config/.hadolint.yml
+++ b/files/common/config/.hadolint.yml
@@ -14,4 +14,4 @@ trustedRegistries:
   - docker.io
   - quay.io
   - "*.pkg.dev"
-  - "cgr.dev/chainguard"
+  - "cgr.dev"


### PR DESCRIPTION
Apparently no `/` is allowed, just the base URL