### PR TITLE
Update common files

### DIFF
--- a/files/.devcontainer/devcontainer.json
+++ b/files/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "istio build-tools",
-  "image": "gcr.io/istio-testing/build-tools:master-5f41028f26adf855f0dd0bfd8781621f0a57d471",
+  "image": "gcr.io/istio-testing/build-tools:master-89ff97db972e1ec7d61a7831bf9408f509e17d73",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -50,7 +50,7 @@ lint-python:
 	@${FINDFILES} -name '*.py' \( ! \( -name '*_pb2.py' \) \) -print0 | ${XARGS} autopep8 --max-line-length 160 --exit-code -d
 
 lint-markdown:
-	@${FINDFILES} -name '*.md' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb
+	@${FINDFILES} -name '*.md' -not -path './manifests/addons/dashboards/*' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb
 
 lint-links:
 	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow_ssl --allow-timeout --allow-dupe --allow-redirect --white-list ${MARKDOWN_LINT_ALLOWLIST}

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -75,7 +75,7 @@ fi
 TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-gcr.io}
 PROJECT_ID=${PROJECT_ID:-istio-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  IMAGE_VERSION=master-5f41028f26adf855f0dd0bfd8781621f0a57d471
+  IMAGE_VERSION=master-89ff97db972e1ec7d61a7831bf9408f509e17d73
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   IMAGE_NAME=build-tools


### PR DESCRIPTION
Replaces https://github.com/istio/common-files/pull/1057

Fixes

```
 $ IMG=gcr.io/istio-testing/build-tools:master-89ff97db972e1ec7d61a7831bf9408f509e17d73 make lint
...
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:522: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:533: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:545: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:558: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:571: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:582: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:593: MD022 Headers should be surrounded by blank lines
./manifests/addons/dashboards/vendor/github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/docs/panel/candlestick/index.md:604: MD022 Headers should be surrounded by blank lines
...
```