### PR TITLE
Fix integ-suite-kind.sh for deploying IPv6/dualStack clusters

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -174,13 +174,9 @@ function setup_kind_cluster() {
     CONFIG=${DEFAULT_CLUSTER_YAML}
   fi
 
-  # Configure the cluster IP Family if explicitly set
-  if [ "${IP_FAMILY}" != "ipv4" ]; then
-    grep "ipFamily: ${IP_FAMILY}" "${CONFIG}" || \
-    cat <<EOF >> "${CONFIG}"
-networking:
-  ipFamily: ${IP_FAMILY}
-EOF
+  # Configure the ipFamily of the cluster
+  if [ -n "${IP_FAMILY}" ]; then
+      yq eval ".networking.ipFamily = \"${IP_FAMILY}\"" -i "${CONFIG}"
   fi
 
   KIND_WAIT_FLAG="--wait=180s"


### PR DESCRIPTION
In a fresh setup, when we try to deploy a dualStack Kind cluster using the `./prow/integ-suite-kind.sh` script by exporting IP_FAMILY=dual, everything works fine. However, when we rerun the command with IP_FAMILY set to "IPv6" the script fails to deploy the cluster.

```
+ echo 'Could not setup KinD environment. Something wrong with KinD setup. Exporting logs.'
Could not setup KinD environment. Something wrong with KinD setup. Exporting logs.
```

This PR fixes the issue and ensures that only one "networking.ipFamily" entry is configured in the Kind config.