### PR TITLE
update kind-provisioner.sh to stop mutating kind config files

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -34,6 +34,9 @@ set -x
 # DEFAULT_KIND_IMAGE is used to set the Kubernetes version for KinD unless overridden in params to setup_kind_cluster(s)
 DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.28.4"
 
+# the default kind cluster should be ipv4 if not otherwise specified
+IP_FAMILY="${IP_FAMILY:-ipv4}"
+
 # COMMON_SCRIPTS contains the directory this file is in.
 COMMON_SCRIPTS=$(dirname "${BASH_SOURCE:-$0}")
 
@@ -174,11 +177,6 @@ function setup_kind_cluster() {
     CONFIG=${DEFAULT_CLUSTER_YAML}
   fi
 
-  # Configure the ipFamily of the cluster
-  if [ -n "${IP_FAMILY}" ]; then
-      yq eval ".networking.ipFamily = \"${IP_FAMILY}\"" -i "${CONFIG}"
-  fi
-
   KIND_WAIT_FLAG="--wait=180s"
   KIND_DISABLE_CNI="false"
   if [[ -n "${KUBERNETES_CNI:-}" ]]; then
@@ -187,7 +185,8 @@ function setup_kind_cluster() {
   fi
 
   # Create KinD cluster
-  if ! (yq eval "${CONFIG}" --expression ".networking.disableDefaultCNI = ${KIND_DISABLE_CNI}" | \
+  if ! (yq eval "${CONFIG}" --expression ".networking.disableDefaultCNI = ${KIND_DISABLE_CNI}" \
+    --expression ".networking.ipFamily = \"${IP_FAMILY}\"" | \
     kind create cluster --name="${NAME}" -v4 --retain --image "${IMAGE}" ${KIND_WAIT_FLAG:+"$KIND_WAIT_FLAG"} --config -); then
     echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
     return 9


### PR DESCRIPTION
This is intended to stop kind_provisioner.sh from mutating kind config files on disk. I did add some defaulting of IP_FAMILY here even though integ-suite-kind.sh also defaults this. I am not sure if anyone uses the provisioner in and of itself but I suspect someone does and adding defaulting here should keep their UX the same, near as I can tell at least.

https://github.com/istio/istio/pull/52780 is the same change in istio/istio to be able to test for any impact. Please comment there to kick off any integ tests which you have concerns this change may impact.