### PR TITLE
Fix interactive check

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -36,7 +36,7 @@ MOUNT_DEST="${MOUNT_DEST:-/work}"
 
 read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 
-[[ -t 1 ]] && DOCKER_RUN_OPTIONS+=("-it")
+[[ -t 0 ]] && DOCKER_RUN_OPTIONS+=("-it")
 [[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=(-u "${UID}:${DOCKER_GID}")
 
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the


### PR DESCRIPTION
This is checking "If stdout is a terminal, use -it". However, docker
actually requires *stdin* to be a terminal -- its fine if stdout isn't!

Without this patch:
```
$ echo | make help
the input device is not a TTY
```
