### PR TITLE
use copyloopvar instead of exportloopref

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -16,7 +16,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
-    - exportloopref
+    - copyloopvar
     - depguard
     - gocritic
     - gofumpt


### PR DESCRIPTION
```console
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```

xref: https://github.com/istio/istio/pull/53633