### PR TITLE
Revert "Automator: update build-tools image@release-1.24 in istio/common-files@release-1.24"

### DIFF
--- a/files/.devcontainer/devcontainer.json
+++ b/files/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "istio build-tools",
-  "image": "gcr.io/istio-testing/build-tools:release-1.24-53d83bbbccb6173ccc6804edfe8c7e221592dcda",
+  "image": "gcr.io/istio-testing/build-tools:master-4759bf88d40172234fc6a0b9e11a4c5f1ea58a90",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -75,7 +75,7 @@ fi
 TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-gcr.io}
 PROJECT_ID=${PROJECT_ID:-istio-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  IMAGE_VERSION=release-1.24-53d83bbbccb6173ccc6804edfe8c7e221592dcda
+  IMAGE_VERSION=master-4759bf88d40172234fc6a0b9e11a4c5f1ea58a90
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   IMAGE_NAME=build-tools


### PR DESCRIPTION
Reverts istio/common-files#1101

According to step 4 

Automation Step 4
This step has a two steps:
--
Run the automation
Merge the PRs created by it, EXCEPT FOR ONE! As part of the STEP 4 PR post-submits, a new PR will be created in the istio/common-files repo with a title like: Automator: update build-tools image@release-1.24 in istio/common-files@release-1.24. The work in this PR is only a portion of Step 5, and merging it will cause issues with reverting the repos to the main branch common-files. CLOSE this PR.
