### PR TITLE
KinD: Fix access to loadbalancerIPs from the host network

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -194,6 +194,9 @@ function setup_kind_cluster() {
   # Workaround kind issue causing taints to not be removed in 1.24
   kubectl taint nodes "${NAME}"-control-plane node-role.kubernetes.io/control-plane- 2>/dev/null || true
 
+  # Remove the label from the nodes to ensure LoadBalancer IPs are accessible from the host network, specifically for single-node clusters.
+  kubectl label nodes --all node.kubernetes.io/exclude-from-external-load-balancers- 2>/dev/null || true
+
   # Determine what CNI to install
   case "${KUBERNETES_CNI:-}" in 
 


### PR DESCRIPTION
When deploying a kind cluster using integ-suite-kind.sh along with metallb, it was seen that LoadBalancer IPs were inaccessible from the host network. This is because kubeadm clusters automatically configure the `node.kubernetes.io/exclude-from-external-load-balancers` label on control plane nodes. Metallb respects this label and avoids announcing services from these nodes.

Since we create a single-node kind cluster in the script, the LoadBalancer IPs for services remain unreachable from the host network.

To resolve this issue, we have two options:
1. Remove the label from nodes, as [documented ](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#control-plane-node-isolation)on the kubeadm page.
2. Upgrade metallb version to 0.14.4, which supports ignoring the label using the [--ignore-exclude-lb](https://metallb.universe.tf/release-notes/#version-0144) flag.

This PR implements option 1, as it’s the simplest solution and aligns with our existing approach for removing taints.