### PR TITLE
remove special casing of CC license we are not going to use

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -106,11 +106,6 @@ update-common:
 	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
 	fi
-# istio/istio.io uses the  Creative Commons Attribution 4.0 license. Don't update LICENSE with the common Apache license.
-	@LICENSE_OVERRIDE=$(shell grep -l "Creative Commons Attribution 4.0 International Public License" LICENSE)
-	@if [ "$(LICENSE_OVERRIDE)" != "LICENSE" ]; then\
-		rm $(TMP)/common-files/files/LICENSE;\
-	fi
 	@cp -a $(TMP)/common-files/files/* $(TMP)/common-files/files/.devcontainer $(TMP)/common-files/files/.gitattributes $(shell pwd)
 	@rm -fr $(TMP)/common-files
 	@$(or $(COMMONFILES_POSTPROCESS), true)


### PR DESCRIPTION
We [added logic](https://github.com/istio/common-files/pull/999) to the script to deal with the fact that [we intended to make the Istio docs licensed under CC-BY 4.0](https://github.com/istio/istio.io/pull/14670).  Turns out [we can't do that](https://github.com/cncf/foundation/issues/230#issuecomment-2009694584) without seeking permission from all the authors, which doesn't seem worth the squeeze.  Backing out the logic.
