### PR TITLE
[DNM] Build container needs `SYS_ADMIN`

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -47,6 +47,7 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
     "${DOCKER_RUN_OPTIONS[@]}" \
     --init \
     --sig-proxy=true \
+    --cap-add=SYS_ADMIN \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
     $CONTAINER_OPTIONS \
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \


### PR DESCRIPTION
https://github.com/istio/istio/pull/55228 added this in-repo but it needs to go in common-files.

I'm not entirely sure we need to or want to run the whole build container with `SYS_ADMIN` tho - we had this same problem over in istio/ztunnel.

I'm opening this just for tracking/visibility purposes since the change already entered `master`.