### PR TITLE
fix docker_host scripts

### DIFF
--- a/files/common/scripts/run.sh
+++ b/files/common/scripts/run.sh
@@ -49,6 +49,7 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
     --sig-proxy=true \
     --cap-add=SYS_ADMIN \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
+    -e DOCKER_HOST=${DOCKER_SOCKET_HOST:-unix:///var/run/docker.sock} \
     $CONTAINER_OPTIONS \
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
     -e IN_BUILD_CONTAINER=1 \


### PR DESCRIPTION
Moving fix from https://github.com/istio/istio/pull/55123 to this repo

**Please provide a description of this PR:**

The setup-env.sh script binds into the build container the `$HOME/.docker/...` directory tree.

In that configuration there is a concrete path to the docker socket that points to a path on the host - `$HOME/.docker/run/docker.sock`

This breaks the build (on Mac OS/arm) because docker in the container reads this config to find the socket.

This PR instead explicitly sets `DOCKER_HOST` to point to where the docker socket is being mounted into the container.

If a user is setting `DOCKER_SOCKET_MOUNT` they can set `DOCKER_SOCKET_HOST` to change the `DOCKER_HOST` variable in the container.