### PR TITLE
update revive rule name to imports-blocklist

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -94,7 +94,7 @@ linters-settings:
       - name: constant-logical-expr
       - name: bool-literal-in-expr
       - name: redefines-builtin-id
-      - name: imports-blacklist
+      - name: imports-blocklist
       - name: range-val-in-closure
       - name: range-val-address
       - name: waitgroup-by-value


### PR DESCRIPTION
The `revive` rule `imports-blacklist` was renamed to `imports-blocklist` a year ago in mgechev/revive#946.

See https://github.com/golangci/golangci-lint/blob/132365e252c985a191c6eaea3f0cc01ca9120ccc/.golangci.reference.yml#L2665C9-L2665C92
