### PR TITLE
remove 'typecheck' linter because it's always enabled

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -29,7 +29,6 @@ linters:
     - misspell
     - staticcheck
     - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused


### PR DESCRIPTION
This PR removes redundant `typecheck` from the `linters.enable` list.

`typecheck` is not a linter and it doesn't perform any analysis. It's just a way to identify, parse, and display compiling errors and some linter errors.

More info:

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors