### PR TITLE
exclude node_modules from getting linted

### DIFF
--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -59,7 +59,7 @@ lint-sass:
 	@${FINDFILES} -name '*.scss' -print0 | ${XARGS} sass-lint -c common/config/sass-lint.yml --verbose
 
 lint-typescript:
-	@${FINDFILES} -name '*.ts' -print0 | ${XARGS} tslint -c common/config/tslint.json
+	@${FINDFILES} -name '*.ts' -not -path "./node_modules/*"  -print0 | ${XARGS} tslint -c common/config/tslint.json
 
 lint-licenses:
 	@if test -d licenses; then license-lint --config common/config/license-lint.yml; fi

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -59,7 +59,7 @@ lint-sass:
 	@${FINDFILES} -name '*.scss' -print0 | ${XARGS} sass-lint -c common/config/sass-lint.yml --verbose
 
 lint-typescript:
-	@${FINDFILES} -name '*.ts' -not -path "./node_modules/*"  -print0 | ${XARGS} tslint -c common/config/tslint.json
+	@${FINDFILES} . -type d -name node_modules -prune -o -name '*.ts' -print0 | ${XARGS} tslint -c common/config/tslint.json
 
 lint-licenses:
 	@if test -d licenses; then license-lint --config common/config/license-lint.yml; fi


### PR DESCRIPTION
This PR excludes the node_modules to be linted by the typescript linter