### PR TITLE
Relabel bind mounts for SELinux

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -120,24 +120,27 @@ done
 CONDITIONAL_HOST_MOUNTS="${CONDITIONAL_HOST_MOUNTS:-} "
 container_kubeconfig=''
 
+# When adding volumes, bind mounts must use --volume so that they
+# can be configured for SELinux labeling
+
 # docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--volume ${HOME}/.docker:/config/.docker:ro "
 fi
 
 # gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
 if [[ -d "${HOME}/.config/gcloud" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--volume ${HOME}/.config/gcloud:/config/.config/gcloud:ro "
 fi
 
 # gitconfig conditional host mount (needed for git commands inside container)
 if [[ -f "${HOME}/.gitconfig" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.gitconfig,destination=/home/.gitconfig,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--volume ${HOME}/.gitconfig:/home/.gitconfig:ro "
 fi
 
 # .netrc conditional host mount (needed for git commands inside container)
 if [[ -f "${HOME}/.netrc" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.netrc,destination=/home/.netrc,readonly "
+  CONDITIONAL_HOST_MOUNTS+="--volume ${HOME}/.netrc:/home/.netrc:ro "
 fi
 
 # echo ${CONDITIONAL_HOST_MOUNTS}
@@ -153,7 +156,7 @@ add_KUBECONFIG_if_exists () {
 
     kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
     container_kubeconfig+="/config/${kubeconfig_random}:"
-    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${local_config},destination=/config/${kubeconfig_random} "
+    CONDITIONAL_HOST_MOUNTS+="--volume ${local_config}:/config/${kubeconfig_random} "
   fi
 }
 


### PR DESCRIPTION
When SELinux is enabled and enforcing, bind mounts need to be relabeled to work correctly in many cases. This is configured by adding the "z" option to --volume definitions (it is not supported with --mount type=bind).

This adds a relabeling function to run.sh which adds the appropriate option to --volume definitions, and warns if it finds a --mount type=bind option. It also converts --mount type=bind declarations to the corresponding --volume definition.