### PR TITLE
golangci-lint: ignore meaningless package names

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -184,6 +184,10 @@ linters:
       - linters:
           - staticcheck
         text: 'S1007'
+      # TODO: remove once we have updated package names
+      - linters:
+        - revive
+        text: "var-naming: avoid meaningless package names"
     paths:
       - .*\.pb\.go
       - .*\.gen\.go


### PR DESCRIPTION
Should fix failing lint and gencheck jobs