### PR TITLE
update kind to use 1.34 as the default k8s version

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -32,7 +32,7 @@ set -x
 ####################################################################
 
 # DEFAULT_KIND_IMAGE is used to set the Kubernetes version for KinD unless overridden in params to setup_kind_cluster(s)
-DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.33.1"
+DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.34.0"
 
 # the default kind cluster should be ipv4 if not otherwise specified
 KIND_IP_FAMILY="${KIND_IP_FAMILY:-ipv4}"


### PR DESCRIPTION
Depends on https://github.com/istio/tools/pull/3269

Will wait until test-infra updates and the build from tools has been propagated to other repos