### PR TITLE
cypher/filepath-securejoin is licensed under BSD and MP-2.0; both app…

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -143,3 +143,9 @@ allowlisted_modules:
 
 # Simplified BSD License: https://github.com/gomarkdown/markdown/blob/master/LICENSE.txt
 - github.com/gomarkdown/markdown
+
+# MPL-2.0
+# https://github.com/cyphar/filepath-securejoin/blob/main/LICENSE.MPL-2.0
+# BSD
+# https://github.com/cyphar/filepath-securejoin/blob/main/LICENSE.BSD
+- github.com/yphar/filepath-securejoin


### PR DESCRIPTION
…roved for use by istio