### PR TITLE
Fixing incorrect build-tools image

### DIFF
--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -77,7 +77,7 @@ fi
 TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-registry.istio.io}
 PROJECT_ID=${PROJECT_ID:-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  IMAGE_VERSION=master-ff93080f0b66b1649fd6f3bfa6b63f74be377937
+  IMAGE_VERSION=master-b7201a4e3411e85dff202449182d26efd7491b89
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   IMAGE_NAME=build-tools


### PR DESCRIPTION
This change used very old image https://github.com/istio/common-files/pull/1261/changes#diff-1be94e128e31b7ece58ee35d56d1e95cf1aee5a371f5139a555df8b0e718d086R80 Reverting that back to the latest available image