### PR TITLE
Add helm.sh/helm/v4 to license allowlist

### DIFF
--- a/files/common/config/license-lint.yml
+++ b/files/common/config/license-lint.yml
@@ -80,6 +80,7 @@ allowlisted_modules:
 # Helm is Apache 2.0: https://github.com/helm/helm/blob/master/LICENSE
 # However, it has a bunch of LICENSE test files that our linter fails to understand
 - helm.sh/helm/v3
+- helm.sh/helm/v4
 
 # https://github.com/pelletier/go-toml/blob/master/LICENSE
 # Uses MIT for everything, except a few files copied from


### PR DESCRIPTION
istio-ecosystem/sail-operator recently migrated to Helm v4. Like v3, it ships test fixture LICENSE files that the linter cannot recognize, causing lint failures in the update-deps automation.