### PR TITLE
Expand metallb LB IP space for gateway conformance tests

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -416,20 +416,20 @@ function install_metallb() {
     METALLB_IPS4=()
     while read -r ip; do
       METALLB_IPS4+=("$ip")
-    done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
+    done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 400)
     METALLB_IPS6=()
     if [[ "$(docker inspect kind | jq '.[0].IPAM.Config | length' -r)" == 2 ]]; then
       # Two configs? Must be dual stack.
       DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[1].Subnet' -r)"
       while read -r ip; do
         METALLB_IPS6+=("$ip")
-      done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
+      done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 400)
     fi
   fi
 
   # Give this cluster of those IPs
   RANGE="["
-  for i in {0..19}; do
+  for i in {0..49}; do
     RANGE+="${METALLB_IPS4[1]},"
     METALLB_IPS4=("${METALLB_IPS4[@]:1}")
     if [[ "${#METALLB_IPS6[@]}" != 0 ]]; then


### PR DESCRIPTION
I think we've outgrown the IP space for gateway conformance tests. The number of gateways created as part of the conformance suite have grown considerably, and in CI logs there are intermittent `AddressNotAssigned` errors that are (probably) slowing CI down.

[CI run example](https://1eb8152ceed73d3ee6f66c3557819d4c.r2.cloudflarestorage.com/istio-prow/logs/integ-pilot_istio_postsubmit/2075561377765789696/build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6f7b33c954a514b4fddd76e3fd62ce66%2F20260710%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260710T151844Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=c8c604e0c8a52b7f6afae4cc6289d5a4ea5df88fdf789cf3f83306a1e368a4e0)