### PR TITLE
[release-1.31] Revert build-tools update and automated step 5

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @istio/release-managers-1-31
+* @istio/wg-test-and-release-maintainers

--- a/files/.devcontainer/devcontainer.json
+++ b/files/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "istio build-tools",
-  "image": "registry.istio.io/testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5",
+  "image": "registry.istio.io/testing/build-tools:master-6db0b4c7fbe345bd531a07fbcff13877dc9cd801",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",

--- a/files/common/Makefile.common.mk
+++ b/files/common/Makefile.common.mk
@@ -92,7 +92,7 @@ mirror-licenses: mod-download-go
 	@license-lint --mirror
 
 TMP := $(shell mktemp -d -u)
-UPDATE_BRANCH ?= "release-1.31"
+UPDATE_BRANCH ?= "master"
 
 BUILD_TOOLS_ORG ?= "istio"
 

--- a/files/common/scripts/setup_env.sh
+++ b/files/common/scripts/setup_env.sh
@@ -77,7 +77,7 @@ fi
 TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-registry.istio.io}
 PROJECT_ID=${PROJECT_ID:-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  IMAGE_VERSION=release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  IMAGE_VERSION=master-6db0b4c7fbe345bd531a07fbcff13877dc9cd801
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   IMAGE_NAME=build-tools


### PR DESCRIPTION
This PR reverts #1291 and #1294 to undo incorrect automation triggered during the Istio 1.31 release process.

Per the [Prepare Istio 1.31 release instructions](https://github.com/istio/istio/issues/60658), the automated PR updating the build-tools image (#1291) should have been closed after step 3, as it triggers changes that are difficult to revert. It was mistakenly approved and merged, which caused automated step 5 (#1294) to propagate wrong automation PRs to downstream repos (e.g. istio/ztunnel#2028, istio/ztunnel#2026).

This revert undoes both commits so that the incorrect changes are reverted from downstream repos (istio, ztunnel, etc.) via their automation. Automated step 5 will be re-run afterward to trigger the expected PRs.