### PR TITLE
Default NOMETALBINSTALL in setup_kind_clusters

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -345,7 +345,7 @@ EOF
   for CLUSTER_NAME in "${CLUSTER_NAMES[@]}"; do
     KUBECONFIG_FILE="${KUBECONFIG_DIR}/${CLUSTER_NAME}"
     if [[ ${NUM_CLUSTERS} -gt 1 ]]; then
-      if [[ -z "${NOMETALBINSTALL}" ]]; then
+      if [[ -z "${NOMETALBINSTALL:-}" ]]; then
         retry install_metallb "${KUBECONFIG_FILE}"
       fi
     fi


### PR DESCRIPTION
`setup_kind_clusters` guards the MetalLB install on `NOMETALBINSTALL` but never
defaults it, unlike `setup_kind_cluster`. Callers that don't export the variable
fail under `set -u` once more than one cluster is up:

```
common/scripts/kind_provisioner.sh: line 348: NOMETALBINSTALL: unbound variable
```

istio/istio exports it in `prow/integ-suite-kind.sh`, so this only shows up
elsewhere — istio.io's multicluster doc test hits it after all three clusters
provision successfully.
