### PR TITLE
Upgrade default KIND node to v1.36

### DIFF
--- a/files/common/scripts/kind_provisioner.sh
+++ b/files/common/scripts/kind_provisioner.sh
@@ -32,7 +32,7 @@ set -x
 ####################################################################
 
 # DEFAULT_KIND_IMAGE is used to set the Kubernetes version for KinD unless overridden in params to setup_kind_cluster(s)
-DEFAULT_KIND_IMAGE="registry.istio.io/testing/kind-node:v1.35.0"
+DEFAULT_KIND_IMAGE="registry.istio.io/testing/kind-node:v1.36.0"
 
 # the default kind cluster should be ipv4 if not otherwise specified
 KIND_IP_FAMILY="${KIND_IP_FAMILY:-ipv4}"


### PR DESCRIPTION
The [support status](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) table shows that we support k8s 1.36, but 1.35 is the highest version used in tests for now.