### PR TITLE
disable unparam from linter until v2.13.2 golangci-lint is released

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - revive
     - staticcheck
     - unconvert
-    - unparam
+    # - unparam # disabled: panics on Go 1.27 with generics (golangci-lint#6755); re-enable after v2.13.2+ is released
     - unused
   settings:
     depguard:


### PR DESCRIPTION
Disable on master branch only`unparam` until a new version of golangci-lint is out with the fix for the error. We will still catch `unparam` issues on release branches because Go 1.28 is going to be set only on master at least until next Istio version