### PR TITLE
Enable unparam in golangci.yml again

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - revive
     - staticcheck
     - unconvert
-    # - unparam # disabled: panics on Go 1.27 with generics (golangci-lint#6755); re-enable after v2.13.2+ is released
+    - unparam
     - unused
   settings:
     depguard:


### PR DESCRIPTION
Once https://github.com/istio/tools/pull/3465 is merged and build-tools is updated across all the repo we can enable unparam again. I ran some tests locally in the istio/istio repo with the new version and it's working fine:

```
 export PATH=/tmp/golint:$PATH
golangci-lint run -c ./common/config/.golangci.yml \
  --enable-only=unparam \
  ./pkg/slices/...
0 issues.
golangci-lint run -c ./common/config/.golangci.yml \
  --enable-only=unparam \
  ./pilot/pkg/model/... ./pkg/config/... ./istioctl/pkg/...
0 issues.
golangci-lint run -c ./common/config/.golangci.yml \
  --enable-only=unparam \
  ./pilot/...
0 issues.
```