### PR TITLE
Add staticcheck 2.17 SA1019 exclusions for golangci-lint v2.13

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -159,6 +159,9 @@ linters:
         text: 'SA1019: "github.com/golang/protobuf/jsonpb"'
       - linters:
           - staticcheck
+        text: 'SA1019: github.com/golang/protobuf/jsonpb is deprecated'
+      - linters:
+          - staticcheck
         text: 'SA1019: grpc.Dial is deprecated: use NewClient instead'
       - linters:
           - staticcheck


### PR DESCRIPTION
Add SA1019 exclusions for staticcheck 2.17 deprecation message format changes. This is needed to bump the golangci-lint version on this PR https://github.com/istio/tools/pull/3465 and needs to be merged before https://github.com/istio/common-files/pull/1308. The order will be this:

1. common-files→  SA1019 exclusions
2. tools→  update-common + golangci-lint 2.13.2 bump
3. wait→  build-tools image + test-infra automator
4. common-files→  re-enable unparam
5. automator→  rolls unparam to all repos