### PR TITLE
add SA1019 exclusions for staticcheck 2.17 / golangci-lint v2.13

### DIFF
--- a/files/common/config/.golangci.yml
+++ b/files/common/config/.golangci.yml
@@ -175,6 +175,34 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: grpc.WithReturnConnectionError'
+      - linters:
+          - staticcheck
+        text: 'SA1019: google.golang.org/grpc.Dial is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: google.golang.org/grpc.DialContext is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: google.golang.org/grpc.WithBlock is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: google.golang.org/grpc.FailOnNonTempDialError'
+      - linters:
+          - staticcheck
+        text: 'SA1019: google.golang.org/grpc.WithReturnConnectionError'
+      # staticcheck 2.17 (golangci-lint v2.13) reports new SA1019 deprecations for APIs we still use intentionally
+      - linters:
+          - staticcheck
+        text: 'SA1019:.*envoyproxy/go-control-plane'
+      - linters:
+          - staticcheck
+        text: 'SA1019:.*istio.io/api'
+      - linters:
+          - staticcheck
+        text: 'SA1019:.*k8s.io/client-go/tools/cache.ListWatch'
+      - linters:
+          - staticcheck
+        text: 'SA1019:.*golang.org/x/net/http2.Transport'
       - path: (.+)\.go$
         text: composite literal uses unkeyed fields
       # TODO: remove following rule in the future


### PR DESCRIPTION
staticcheck 2.17 on golangci-lint v2.13, shipped with the Go 1.27 tools image introduced two breaking changes for the common-files lint config:

* gRPC SA1019 warnings now use the full package path (`google.golang.org/grpc.Dial`) instead of the short form (`grpc.Dial`), so the existing exclusions stopped matching.
* New SA1019 deprecations are reported for APIs Istio intentionally uses: `envoyproxy/go-control-plane`, `istio.io/api`, `k8s.io/client-go/tools/cache.ListWatch`, and `golang.org/x/net/http2.Transport`.

This caused both `update-common` and `update-common-mainonly` postsubmit jobs to fail with 140 staticcheck issues whenever common-files was propagated to downstream repos, examples: https://aws.prow.istio.io/view/s3/istio-prow/logs/update-common_common-files_postsubmit/2097734841020715008 and https://aws.prow.istio.io/view/s3/istio-prow/logs/update-common-mainonly_common-files_postsubmit/2097719035012583424